### PR TITLE
Fix chat message state reference

### DIFF
--- a/src/store/modules/chat.js
+++ b/src/store/modules/chat.js
@@ -3,7 +3,7 @@ export default {
   state: {
     connected: false,
     error: null,
-    messages: [],
+    chatMessages: [],
     limit: 50,
   },
   getters: {


### PR DESCRIPTION
## Summary
- rename `messages` state to `chatMessages` in chat module

## Testing
- `CI=true npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6860668776dc832797cccf645fef7d11