### PR TITLE
Add websocket event handling

### DIFF
--- a/src/mixins/socket.js
+++ b/src/mixins/socket.js
@@ -43,10 +43,22 @@ export default {
       }
     },
     movement(data) {
-
+      if (data && data.body) {
+        if (data.body.entities) {
+          this.$store.commit('arena/setEntities', data.body.entities);
+        }
+        if (data.body.active) {
+          this.$store.commit('arena/setActive', data.body.active);
+        }
+      }
     },
     chat(data) {
-
+      if (data && data.body) {
+        const message = data.body.message || data.body;
+        if (message) {
+          this.$store.commit('chat/ADD_MESSAGE', message);
+        }
+      }
     },
     arena(data) {
       this.$store.commit('arena/setTerrain', data.body.terrain)


### PR DESCRIPTION
## Summary
- update socket mixin to process `movement` and `chat` events

## Testing
- `npm run build`
- `node test_client.js` (with a temporary test server)

------
https://chatgpt.com/codex/tasks/task_e_686066c681a88327b632b89f109a6d9a