### PR TITLE
refactor dialog and carousel components

### DIFF
--- a/src/components/dialogs/BasicDialog.vue
+++ b/src/components/dialogs/BasicDialog.vue
@@ -9,7 +9,6 @@
         <span class="headline">{{ title }} ({{ keybind }})</span>
       </v-card-title>
       <v-card-text>
-        <!-- This is the slot for parent content -->
         <slot />
       </v-card-text>
       <v-card-actions>
@@ -27,39 +26,32 @@
   </v-dialog>
 </template>
 
-<script>
-export default {
-  props: {
-    modelValue: { // Vue 3 v-model
-      type: Boolean,
-      required: true
-    },
-    title: {
-      type: String,
-      default: '-'
-    },
-    keybind: {
-      type: String,
-      default: 'Not Set'
-    }
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+  modelValue: {
+    type: Boolean,
+    required: true,
   },
-  emits: ['update:modelValue'],
-  computed: {
-    // We use a Vuex state variable as a model for the dialog's visibility
-    dialogState: {
-      get() {
-        return this.modelValue;
-      },
-      set(value) {
-        // This event updates the parent component's state variable
-        this.$emit('update:modelValue', value);
-      }
-    }
+  title: {
+    type: String,
+    default: '-',
   },
-  methods: {
-    closeDialog() {
-      this.$emit('update:modelValue', false); // Close dialog by emitting false
-    }
-  }
-};
+  keybind: {
+    type: String,
+    default: 'Not Set',
+  },
+});
+const emit = defineEmits(['update:modelValue']);
+
+const dialogState = computed({
+  get: () => props.modelValue,
+  set: (value) => emit('update:modelValue', value),
+});
+
+function closeDialog() {
+  dialogState.value = false;
+}
 </script>
+

--- a/src/components/general/FancyCarosel.vue
+++ b/src/components/general/FancyCarosel.vue
@@ -4,7 +4,6 @@
       <v-btn
         fab
         small
-        class=""
         @click="prev"
       >
         <v-icon>
@@ -18,21 +17,18 @@
     >
       <v-layout
         class="content"
-        :style="`margin-left: -${(index) * 416}px`"
+        :style="`margin-left: -${index * 416}px`"
       >
         <slot />
       </v-layout>
-      <div
-        class="d-flex justify-center align-center pa-2"
-      >
-        <!-- icons to show location in list -->
+      <div class="d-flex justify-center align-center pa-2">
         <v-icon
-          v-for="n in $slots.default.length"
+          v-for="n in slotCount"
           :key="n"
           :color="n === index + 1 ? 'white' : 'grey'"
           x-small
           class="mx-1"
-          @click="index = n-1"
+          @click="index = n - 1"
         >
           {{ mdiCircle }}
         </v-icon>
@@ -45,7 +41,6 @@
       <v-btn
         fab
         small
-        class=""
         @click="next"
       >
         <v-icon>
@@ -56,27 +51,25 @@
   </div>
 </template>
 
-<script>
+<script setup>
+import { ref, computed } from 'vue';
 import { mdiCircle, mdiChevronRight, mdiChevronLeft } from '@mdi/js';
 
-export default {
-  data: () => ({
-      mdiCircle,
-      mdiChevronRight,
-      mdiChevronLeft,
-      index: 0,
-  }),
-  methods: {
-    next() {
-      if (this.index < this.$slots.default.length - 1) {
-        this.index += 1;
-      }
-    },
-    prev() {
-      if (this.index > 0) {
-        this.index -= 1;
-      }
-    },
-  },
-};
+const index = ref(0);
+const slots = defineSlots();
+
+const slotCount = computed(() => (slots.default ? slots.default().length : 0));
+
+function next() {
+  if (index.value < slotCount.value - 1) {
+    index.value += 1;
+  }
+}
+
+function prev() {
+  if (index.value > 0) {
+    index.value -= 1;
+  }
+}
 </script>
+


### PR DESCRIPTION
## Summary
- refactor basic dialog component to script setup with computed v-model
- update fancy carousel to handle slots with Vue 3 APIs

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689769fdb6508327ba65874e49dd48f5