### PR TITLE
Add arena route and view for testing

### DIFF
--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -44,6 +44,15 @@ export default [
     },
   },
   {
+    path: '/arena',
+    name: 'Arena',
+  component: () => import('@/views/primary/Arena.vue'),
+    meta: {
+      overlay: false,
+      combat_lock: false,
+    },
+  },
+  {
     path: '/worldmap',
     name: 'World Map',
   component: () => import('@/views/primary/WorldMap.vue'),

--- a/src/views/primary/Arena.vue
+++ b/src/views/primary/Arena.vue
@@ -1,0 +1,11 @@
+<template>
+  <v-container class="fill-height d-flex align-center justify-center">
+    <h1>Arena</h1>
+  </v-container>
+</template>
+
+<script>
+export default {
+  name: 'Arena',
+};
+</script>


### PR DESCRIPTION
## Summary
- add `/arena` route
- create placeholder Arena view for future map testing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/router/routes.js src/views/primary/Arena.vue` *(fails: Parsing error: module is not defined; Cannot require() ES Module /workspace/daemios/babel.config.js in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_6897808866548327823607c8e581c205