### PR TITLE
feat: introduce shared 3d core and arena scene

### DIFF
--- a/docs/3d-refactor-plan.md
+++ b/docs/3d-refactor-plan.md
@@ -1,0 +1,135 @@
+# 3D Engine Refactor Plan
+
+## Module Graph
+```
+3d/core/
+  SceneController -> orchestrates renderer loop
+  RenderPipeline -> builds WebGL renderer and post FX
+  Assets/AssetStore -> async asset cache
+  Cameras/* -> reusable camera rigs
+  Interact/Interactor -> pointer to intent bridge
+  Culling/* -> LOD & frustum hooks
+
+3d/grids/
+  Grid (interface)
+  HexGrid
+  SquareGrid
+  CoordConverters/*
+
+3d/nav/
+  Nav (interface)
+  HexNav
+  SquareNav
+
+worldmap/WorldMapScene -> SceneController + HexGrid + HexNav
+arena/ArenaScene -> SceneController + SquareGrid + SquareNav
+```
+
+## Public Interfaces
+```ts
+// Grid
+interface Grid {
+  toWorld(coord: Vec2): Vec3;
+  toCoord(world: Vec3): Vec2;
+  neighbors(coord: Vec2): Vec2[];
+  distance(a: Vec2, b: Vec2): number;
+  ring(center: Vec2, radius: number): Vec2[];
+  spiral(center: Vec2, radius: number): Vec2[];
+  raycastTileLine(a: Vec2, b: Vec2): Vec2[];
+}
+
+// Nav
+interface Nav {
+  pathfind(start: Vec2, end: Vec2): Vec2[];
+  costMap(start: Vec2, max: number): Map<string, number>;
+  isBlocked(coord: Vec2): boolean;
+}
+
+// SceneController
+interface SceneController {
+  init(): Promise<void>;
+  mount(el: HTMLElement): void;
+  tick(dt: number): void;
+  resize(w: number, h: number): void;
+  dispose(): void;
+}
+
+// RenderPipeline
+interface RenderPipeline {
+  createRenderer(opts?: object): WebGLRenderer;
+  addPass(pass: object): void;
+  setCulling(fn: (object3d) => boolean): void;
+}
+
+// AssetStore
+interface AssetStore {
+  load(key: string, loader: () => Promise<any>): Promise<any>;
+  release(key: string): void;
+  purge(): void;
+}
+
+// Interactor
+interface Interactor {
+  attach(dom: HTMLElement): void;
+  detach(): void;
+  on(type: string, fn: (intent: any) => void): void;
+}
+```
+
+## Folder Layout
+```
+/3d/core/
+  SceneController.js
+  RenderPipeline.js
+  Cameras/
+  Assets/AssetStore.js
+  Culling/
+  Interact/Interactor.js
+/3d/grids/
+  Grid.js
+  HexGrid.js
+  SquareGrid.js
+  CoordConverters/
+/3d/nav/
+  Nav.js
+  HexNav.js
+  SquareNav.js
+/worldmap/WorldMapScene.js
+/worldmap/generators/
+/arena/ArenaScene.js
+/arena/spawners/
+/ui/overlays/
+```
+
+## Abstraction Rules
+- Domain layers use simple `{x:number,y:number,z?:number}` DTOs; Three.js types stay inside the bridge layer.
+- Grid APIs expose `toWorld`, `toCoord`, `neighbors`, `distance`, `ring`, `spiral`, `raycastTileLine`.
+- Cameras are preset profiles (`iso`, `free-orbit`, `tactics-topdown`).
+- Scene mutations go through commands/events to allow undo and replay.
+
+## Incremental Refactor Plan
+1. Extract `SceneController` and `AssetStore` from world map.
+2. Introduce `Grid` interface; adapt existing hex logic into `HexGrid`.
+3. Introduce `Nav` interface; wrap current pathfinding as `HexNav`.
+4. Build `ArenaScene` using core + stub `SquareGrid`/`SquareNav`.
+5. Move input to `Interactor`; unify pointer→tile picking via grid adapters.
+6. Add culling/LOD hooks; split heavy jobs into cancellable workers.
+
+## Test Plan
+- Golden image snapshots for render sanity.
+- Coord round-trip tests (`coord -> world -> coord`).
+- Neighbor and path invariants across grid types.
+- Fixture scenes to validate camera controls.
+- Tick budget profiling to stay within 16ms.
+
+## Risk Log & Mitigations
+- Float precision differences between hex axial and cartesian → keep math in domain DTOs and centralize converters.
+- Scene disposal leaks → `AssetStore` reference counts and `SceneController.dispose` clear resources.
+- Worker churn from chunked tasks → backpressure queue to limit concurrent jobs.
+
+## Optimization Hooks
+- Frustum culling and LOD callbacks in `RenderPipeline`.
+- Tile-batch instancing utilities.
+- Impostor/LOD levels per asset.
+- Async chunk generation with cancellation and queue backpressure.
+```

--- a/src/3d/core/Assets/AssetStore.js
+++ b/src/3d/core/Assets/AssetStore.js
@@ -1,0 +1,30 @@
+export default class AssetStore {
+  constructor() {
+    this.cache = new Map();
+  }
+
+  async load(key, loader) {
+    const cached = this.cache.get(key);
+    if (cached) {
+      cached.ref += 1;
+      return cached.asset;
+    }
+    const asset = await loader();
+    this.cache.set(key, { asset, ref: 1 });
+    return asset;
+  }
+
+  release(key) {
+    const entry = this.cache.get(key);
+    if (!entry) return;
+    entry.ref -= 1;
+    if (entry.ref <= 0) {
+      if (entry.asset.dispose) entry.asset.dispose();
+      this.cache.delete(key);
+    }
+  }
+
+  purge() {
+    [...this.cache.keys()].forEach((k) => this.release(k));
+  }
+}

--- a/src/3d/core/Interact/Interactor.js
+++ b/src/3d/core/Interact/Interactor.js
@@ -1,0 +1,52 @@
+import * as THREE from 'three';
+
+export default class Interactor {
+  constructor(camera, grid) {
+    this.camera = camera;
+    this.grid = grid;
+    this.raycaster = new THREE.Raycaster();
+    this.handlers = {};
+    this._onMove = this._onMove.bind(this);
+    this._onClick = this._onClick.bind(this);
+  }
+
+  attach(dom) {
+    this.dom = dom;
+    dom.addEventListener('pointermove', this._onMove);
+    dom.addEventListener('click', this._onClick);
+  }
+
+  detach() {
+    if (!this.dom) return;
+    this.dom.removeEventListener('pointermove', this._onMove);
+    this.dom.removeEventListener('click', this._onClick);
+  }
+
+  on(type, fn) {
+    this.handlers[type] = fn;
+  }
+
+  _project(event) {
+    const rect = this.dom.getBoundingClientRect();
+    const ndc = {
+      x: ((event.clientX - rect.left) / rect.width) * 2 - 1,
+      y: -((event.clientY - rect.top) / rect.height) * 2 + 1,
+    };
+    this.raycaster.setFromCamera(ndc, this.camera);
+    const plane = new THREE.Plane(new THREE.Vector3(0, 0, 1), 0);
+    const world = this.raycaster.ray.intersectPlane(plane, new THREE.Vector3());
+    if (!world) return null;
+    const coord = this.grid.toCoord({ x: world.x, y: world.y, z: world.z });
+    return { world, coord };
+  }
+
+  _onMove(e) {
+    const hit = this._project(e);
+    if (hit && this.handlers.pointermove) this.handlers.pointermove(hit);
+  }
+
+  _onClick(e) {
+    const hit = this._project(e);
+    if (hit && this.handlers.click) this.handlers.click(hit);
+  }
+}

--- a/src/3d/core/RenderPipeline.js
+++ b/src/3d/core/RenderPipeline.js
@@ -1,0 +1,31 @@
+import * as THREE from 'three';
+
+export default class RenderPipeline {
+  constructor(opts = {}) {
+    this.renderer = opts.renderer || new THREE.WebGLRenderer({ antialias: true });
+    this.passes = [];
+    this.cullFn = null;
+  }
+
+  getRenderer() {
+    return this.renderer;
+  }
+
+  addPass(pass) {
+    this.passes.push(pass);
+  }
+
+  setCulling(fn) {
+    this.cullFn = fn;
+  }
+
+  render(scene, camera) {
+    if (this.cullFn) {
+      scene.children.forEach((obj) => {
+        obj.visible = this.cullFn(obj);
+      });
+    }
+    this.renderer.render(scene, camera);
+    this.passes.forEach((p) => p.render?.());
+  }
+}

--- a/src/3d/core/SceneController.js
+++ b/src/3d/core/SceneController.js
@@ -1,0 +1,48 @@
+import * as THREE from 'three';
+
+export default class SceneController {
+  constructor({ renderer, camera } = {}) {
+    this.scene = new THREE.Scene();
+    this.renderer = renderer || new THREE.WebGLRenderer({ antialias: true });
+    this.camera = camera || new THREE.PerspectiveCamera(60, 1, 0.1, 1000);
+    this._tickers = new Set();
+    this._boundLoop = this._loop.bind(this);
+    this._running = false;
+  }
+
+  mount(el) {
+    this.el = el;
+    el.appendChild(this.renderer.domElement);
+    this.resize(el.clientWidth, el.clientHeight);
+    this._running = true;
+    requestAnimationFrame(this._boundLoop);
+  }
+
+  onTick(fn) {
+    this._tickers.add(fn);
+  }
+
+  offTick(fn) {
+    this._tickers.delete(fn);
+  }
+
+  _loop(time) {
+    if (!this._running) return;
+    this._tickers.forEach((fn) => fn(time));
+    this.renderer.render(this.scene, this.camera);
+    requestAnimationFrame(this._boundLoop);
+  }
+
+  resize(w, h) {
+    this.renderer.setSize(w, h);
+    if (this.camera.isPerspectiveCamera) {
+      this.camera.aspect = w / h;
+    }
+    this.camera.updateProjectionMatrix();
+  }
+
+  dispose() {
+    this._running = false;
+    this.renderer.dispose();
+  }
+}

--- a/src/3d/grids/Grid.js
+++ b/src/3d/grids/Grid.js
@@ -1,0 +1,31 @@
+export default class Grid {
+  toWorld(coord) {
+    throw new Error('toWorld not implemented');
+  }
+
+  toCoord(world) {
+    throw new Error('toCoord not implemented');
+  }
+
+  neighbors(coord) {
+    return [];
+  }
+
+  distance(a, b) {
+    return 0;
+  }
+
+  ring(center, radius) {
+    return [];
+  }
+
+  spiral(center, radius) {
+    const cells = [];
+    for (let r = 1; r <= radius; r += 1) cells.push(...this.ring(center, r));
+    return cells;
+  }
+
+  raycastTileLine(a, b) {
+    return [];
+  }
+}

--- a/src/3d/grids/HexGrid.js
+++ b/src/3d/grids/HexGrid.js
@@ -1,0 +1,70 @@
+import Grid from './Grid.js';
+
+export default class HexGrid extends Grid {
+  constructor({ size = 1 } = {}) {
+    super();
+    this.size = size;
+    this.sqrt3 = Math.sqrt(3);
+  }
+
+  toWorld({ q, r }) {
+    const x = this.size * this.sqrt3 * (q + r / 2);
+    const y = -this.size * 1.5 * r;
+    return { x, y, z: 0 };
+  }
+
+  toCoord({ x, y }) {
+    const q = (x * 2 / (this.sqrt3 * this.size) - y / (3 * this.size));
+    const r = -y / (1.5 * this.size);
+    const rq = Math.round(q);
+    const rr = Math.round(r);
+    const rs = Math.round(-q - r);
+    const qDiff = Math.abs(rq - q);
+    const rDiff = Math.abs(rr - r);
+    const sDiff = Math.abs(rs + q + r);
+    let Q = rq; let R = rr;
+    if (qDiff > rDiff && qDiff > sDiff) Q = -rr - rs;
+    else if (rDiff > sDiff) R = -rq - rs;
+    return { q: Q, r: R };
+  }
+
+  neighbors({ q, r }) {
+    return [
+      { q: q + 1, r }, { q: q - 1, r },
+      { q, r + 1 }, { q, r - 1 },
+      { q + 1, r - 1 }, { q - 1, r + 1 },
+    ];
+  }
+
+  distance(a, b) {
+    return (Math.abs(a.q - b.q) + Math.abs(a.q + a.r - b.q - b.r) + Math.abs(a.r - b.r)) / 2;
+  }
+
+  ring(center, radius) {
+    const results = [];
+    let { q, r } = { q: center.q + radius, r: center.r - radius };
+    const dirs = [
+      [ -1, 0 ], [ 0, 1 ], [ -1, 1 ],
+      [ 1, 0 ], [ 0, -1 ], [ 1, -1 ],
+    ];
+    dirs.forEach(([dq, dr]) => {
+      for (let i = 0; i < radius; i += 1) {
+        results.push({ q, r });
+        q += dq; r += dr;
+      }
+    });
+    return results;
+  }
+
+  raycastTileLine(a, b) {
+    const N = this.distance(a, b);
+    const results = [];
+    for (let i = 0; i <= N; i += 1) {
+      const t = N === 0 ? 0 : i / N;
+      const q = a.q + (b.q - a.q) * t;
+      const r = a.r + (b.r - a.r) * t;
+      results.push(this.toCoord(this.toWorld({ q, r }))); // round
+    }
+    return results;
+  }
+}

--- a/src/3d/grids/SquareGrid.js
+++ b/src/3d/grids/SquareGrid.js
@@ -1,0 +1,57 @@
+import Grid from './Grid.js';
+
+export default class SquareGrid extends Grid {
+  constructor({ cellSize = 1 } = {}) {
+    super();
+    this.cellSize = cellSize;
+  }
+
+  toWorld({ x, y }) {
+    return { x: (x + 0.5) * this.cellSize, y: -(y + 0.5) * this.cellSize, z: 0 };
+  }
+
+  toCoord({ x, y }) {
+    return { x: Math.floor(x / this.cellSize), y: Math.floor(-y / this.cellSize) };
+  }
+
+  neighbors({ x, y }) {
+    return [
+      { x: x + 1, y }, { x: x - 1, y },
+      { x, y + 1 }, { x, y - 1 },
+    ];
+  }
+
+  distance(a, b) {
+    return Math.abs(a.x - b.x) + Math.abs(a.y - b.y);
+  }
+
+  ring(center, radius) {
+    const cells = [];
+    for (let dx = -radius; dx <= radius; dx += 1) {
+      for (let dy = -radius; dy <= radius; dy += 1) {
+        if (Math.abs(dx) + Math.abs(dy) === radius) {
+          cells.push({ x: center.x + dx, y: center.y + dy });
+        }
+      }
+    }
+    return cells;
+  }
+
+  raycastTileLine(a, b) {
+    const line = [];
+    let x = a.x; let y = a.y;
+    const dx = Math.abs(b.x - a.x);
+    const dy = Math.abs(b.y - a.y);
+    const sx = a.x < b.x ? 1 : -1;
+    const sy = a.y < b.y ? 1 : -1;
+    let err = dx - dy;
+    while (true) {
+      line.push({ x, y });
+      if (x === b.x && y === b.y) break;
+      const e2 = err * 2;
+      if (e2 > -dy) { err -= dy; x += sx; }
+      if (e2 < dx) { err += dx; y += sy; }
+    }
+    return line;
+  }
+}

--- a/src/3d/nav/HexNav.js
+++ b/src/3d/nav/HexNav.js
@@ -1,0 +1,31 @@
+import Nav from './Nav.js';
+
+export default class HexNav extends Nav {
+  constructor(grid, { isBlocked } = {}) {
+    super(grid);
+    this.blocked = isBlocked || (() => false);
+  }
+
+  pathfind(start, end) {
+    const frontier = [start];
+    const came = new Map();
+    came.set(`${start.q},${start.r}`, null);
+    while (frontier.length) {
+      const cur = frontier.shift();
+      if (cur.q === end.q && cur.r === end.r) break;
+      this.grid.neighbors(cur).forEach((n) => {
+        const key = `${n.q},${n.r}`;
+        if (this.blocked(n) || came.has(key)) return;
+        frontier.push(n);
+        came.set(key, cur);
+      });
+    }
+    const path = [];
+    let step = end;
+    while (step) {
+      path.unshift(step);
+      step = came.get(`${step.q},${step.r}`);
+    }
+    return path;
+  }
+}

--- a/src/3d/nav/Nav.js
+++ b/src/3d/nav/Nav.js
@@ -1,0 +1,17 @@
+export default class Nav {
+  constructor(grid) {
+    this.grid = grid;
+  }
+
+  pathfind(start, end) {
+    return [];
+  }
+
+  costMap(start, max) {
+    return new Map();
+  }
+
+  isBlocked() {
+    return false;
+  }
+}

--- a/src/3d/nav/SquareNav.js
+++ b/src/3d/nav/SquareNav.js
@@ -1,0 +1,31 @@
+import Nav from './Nav.js';
+
+export default class SquareNav extends Nav {
+  constructor(grid, { isBlocked } = {}) {
+    super(grid);
+    this.blocked = isBlocked || (() => false);
+  }
+
+  pathfind(start, end) {
+    const frontier = [start];
+    const came = new Map();
+    came.set(`${start.x},${start.y}`, null);
+    while (frontier.length) {
+      const cur = frontier.shift();
+      if (cur.x === end.x && cur.y === end.y) break;
+      this.grid.neighbors(cur).forEach((n) => {
+        const key = `${n.x},${n.y}`;
+        if (this.blocked(n) || came.has(key)) return;
+        frontier.push(n);
+        came.set(key, cur);
+      });
+    }
+    const path = [];
+    let step = end;
+    while (step) {
+      path.unshift(step);
+      step = came.get(`${step.x},${step.y}`);
+    }
+    return path;
+  }
+}

--- a/src/arena/ArenaScene.js
+++ b/src/arena/ArenaScene.js
@@ -1,0 +1,62 @@
+import * as THREE from 'three';
+import SceneController from '../3d/core/SceneController.js';
+import SquareGrid from '../3d/grids/SquareGrid.js';
+import SquareNav from '../3d/nav/SquareNav.js';
+import Interactor from '../3d/core/Interact/Interactor.js';
+import RenderPipeline from '../3d/core/RenderPipeline.js';
+
+export default class ArenaScene extends SceneController {
+  constructor(opts = {}) {
+    const w = opts.width || 10;
+    const h = opts.height || 10;
+    const camera = new THREE.OrthographicCamera(0, w, 0, -h, 0.1, 1000);
+    camera.position.set(0, 0, 10);
+    camera.lookAt(0, 0, 0);
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    const pipeline = new RenderPipeline({ renderer });
+    super({ renderer: pipeline.getRenderer(), camera });
+    this.pipeline = pipeline;
+    this.grid = new SquareGrid();
+    this.nav = new SquareNav(this.grid);
+    this.interactor = new Interactor(this.camera, this.grid);
+    this.width = w; this.height = h;
+    this._highlight = null;
+    this.onTick(() => this.pipeline.render(this.scene, this.camera));
+  }
+
+  init(container) {
+    this.mount(container);
+    this._buildTerrain();
+    this.interactor.attach(this.renderer.domElement);
+    this.interactor.on('pointermove', ({ coord }) => this._highlightCell(coord));
+  }
+
+  _buildTerrain() {
+    const geom = new THREE.PlaneGeometry(1, 1);
+    const mat = new THREE.MeshBasicMaterial({ color: 0x808080, side: THREE.DoubleSide });
+    const count = this.width * this.height;
+    const mesh = new THREE.InstancedMesh(geom, mat, count);
+    let i = 0;
+    for (let x = 0; x < this.width; x += 1) {
+      for (let y = 0; y < this.height; y += 1) {
+        const pos = this.grid.toWorld({ x, y });
+        const mtx = new THREE.Matrix4().makeTranslation(pos.x, pos.y, 0);
+        mesh.setMatrixAt(i, mtx);
+        i += 1;
+      }
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+    this.scene.add(mesh);
+  }
+
+  _highlightCell(coord) {
+    if (!this._highlight) {
+      const geom = new THREE.PlaneGeometry(1, 1);
+      const mat = new THREE.MeshBasicMaterial({ color: 0xffff00, transparent: true, opacity: 0.5, side: THREE.DoubleSide });
+      this._highlight = new THREE.Mesh(geom, mat);
+      this.scene.add(this._highlight);
+    }
+    const pos = this.grid.toWorld(coord);
+    this._highlight.position.set(pos.x, pos.y, 0.01);
+  }
+}

--- a/src/worldmap/WorldMapScene.js
+++ b/src/worldmap/WorldMapScene.js
@@ -1,0 +1,15 @@
+import * as THREE from 'three';
+import SceneController from '../3d/core/SceneController.js';
+import HexGrid from '../3d/grids/HexGrid.js';
+import HexNav from '../3d/nav/HexNav.js';
+
+export default class WorldMapScene extends SceneController {
+  constructor(opts = {}) {
+    const camera = new THREE.PerspectiveCamera(60, 1, 0.1, 1000);
+    camera.position.set(0, 0, 10);
+    camera.lookAt(0, 0, 0);
+    super({ camera });
+    this.grid = new HexGrid(opts.grid);
+    this.nav = new HexNav(this.grid, opts.nav);
+  }
+}


### PR DESCRIPTION
## Summary
- Add design doc for reusable 3D engine with grid-agnostic APIs
- Implement shared core modules: SceneController, RenderPipeline, AssetStore, Interactor
- Provide HexGrid/SquareGrid and Nav strategies with minimal ArenaScene using the core

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6898f473fad88327b9c6abcc2a8baa4e