### PR TITLE
refactor: scaffold reusable 3d core and arena scene

### DIFF
--- a/docs/3d-refactor-plan.md
+++ b/docs/3d-refactor-plan.md
@@ -1,0 +1,127 @@
+# 3D Core Refactor
+
+## 1. Module graph
+```
+3d/core
+  ├─ SceneController ──> RenderPipeline ──> Three bridge
+  ├─ AssetStore
+  ├─ Interactor
+  └─ Cameras / Culling / etc.
+      ↑          ↑
+      │          └──── hooks for LOD & frustum
+      │
+      └──── domain layers (grid, nav, generation, UI)
+
+worldmap/WorldMapScene ──> HexGrid + HexNav
+arena/ArenaScene ────────> SquareGrid + SquareNav
+```
+
+## 2. Public interfaces
+```ts
+// Grid.ts
+interface Grid {
+  toWorld(coord: Vec2): Vec3
+  toCoord(world: Vec3): Vec2
+  neighbors(coord: Vec2): Vec2[]
+  distance(a: Vec2, b: Vec2): number
+  ring(center: Vec2, radius: number): Vec2[]
+  spiral(center: Vec2, radius: number): Vec2[]
+  raycastTileLine(a: Vec2, b: Vec2): Vec2[]
+}
+
+// Nav.ts
+interface Nav {
+  pathfind(start: Vec2, goal: Vec2): Vec2[]
+  cost(from: Vec2, to: Vec2): number
+  setBlocker(coord: Vec2, blocked: boolean): void
+}
+
+// SceneController.ts
+class SceneController {
+  init(container: HTMLElement): void
+  mount?(): void
+  tick(dt: number): void
+  resize(w: number, h: number): void
+  dispose(): void
+}
+
+// RenderPipeline.ts
+interface RenderPipeline {
+  createRenderer(): WebGLRenderer
+  render(r: WebGLRenderer, s: Scene, c: Camera, dt: number): void
+  mount?(s: Scene, c: Camera, r: WebGLRenderer): void
+  dispose?(): void
+}
+
+// AssetStore.ts
+class AssetStore {
+  load<T>(key: string, loader: (k: string) => Promise<T>): Promise<T>
+  release(key: string): void
+  clear(): void
+}
+
+// Interactor.ts
+class Interactor {
+  constructor(grid: Grid, dispatch: (intent: string, payload: any) => void)
+  pointer(world: Vec3): void
+}
+```
+
+## 3. Folder layout
+```
+/3d/core/
+  SceneController.ts
+  RenderPipeline.ts
+  Cameras/
+  Assets/AssetStore.ts
+  Culling/
+  Interact/Interactor.ts
+/3d/grids/
+  Grid.ts
+  HexGrid.ts
+  SquareGrid.ts
+  CoordConverters/
+/3d/nav/
+  Nav.ts
+  HexNav.ts
+  SquareNav.ts
+/worldmap/
+  WorldMapScene.ts
+  generators/
+/arena/
+  ArenaScene.ts
+  spawners/
+/ui/overlays/
+```
+
+## 4. Abstraction rules
+- Domain uses plain `Vec2`/`Vec3` DTOs; Three.js objects stay inside core bridge.
+- Grid adapters implement `toWorld`, `toCoord`, `neighbors`, `distance`, `ring`, `spiral`, `raycastTileLine`.
+- Cameras provided as preset profiles (`iso`, `free-orbit`, `tactics-topdown`).
+- Scene mutations happen through commands/events for future undo/replay support.
+
+## 5. Incremental refactor plan
+1. Extract `SceneController` and `AssetStore` from world map implementation.
+2. Introduce `Grid` interface; move existing hex logic into `HexGrid`.
+3. Introduce `Nav` interface; wrap current pathfinding as `HexNav`.
+4. Build `ArenaScene` with shared core + stub `SquareGrid/SquareNav`.
+5. Move input to `Interactor`; unify pointer→tile picking via grid adapters.
+6. Add culling/LOD hooks; split heavy tasks into worker jobs.
+
+## 6. Test plan
+- Golden image snapshots for render sanity.
+- Coordinate round‑trip: `coord → world → coord`.
+- Neighbor and pathfinding invariants on small fixtures.
+- Fixture scenes verifying camera controls.
+- Perf budgets per tick measured in CI.
+
+## 7. Risk log & mitigations
+- Float precision differences between axial and cartesian grids → centralize converters, use `Vec` DTOs.
+- Scene disposal leaks → `AssetStore` reference counting and `SceneController.dispose`.
+- Worker job cancellation → expose abort handles on long‑running tasks.
+
+## 8. Optimization hooks
+- Frustum culling entry points in `RenderPipeline` and `Culling/` module.
+- Tile batch instancing and LOD impostors.
+- Async chunk generation with backpressure-aware job queue.
+```

--- a/src/3d/core/Assets/AssetStore.ts
+++ b/src/3d/core/Assets/AssetStore.ts
@@ -1,0 +1,31 @@
+export class AssetStore {
+  private cache = new Map<string, { ref: number; value: any }>()
+
+  async load<T>(key: string, loader: (key: string) => Promise<T>): Promise<T> {
+    const existing = this.cache.get(key)
+    if (existing) {
+      existing.ref++
+      return existing.value as T
+    }
+    const value = await loader(key)
+    this.cache.set(key, { ref: 1, value })
+    return value
+  }
+
+  release(key: string) {
+    const entry = this.cache.get(key)
+    if (!entry) return
+    entry.ref--
+    if (entry.ref <= 0) {
+      ;(entry.value as any)?.dispose?.()
+      this.cache.delete(key)
+    }
+  }
+
+  clear() {
+    for (const [, entry] of this.cache) {
+      ;(entry.value as any)?.dispose?.()
+    }
+    this.cache.clear()
+  }
+}

--- a/src/3d/core/Interact/Interactor.ts
+++ b/src/3d/core/Interact/Interactor.ts
@@ -1,0 +1,19 @@
+import type { Grid } from '../../grids/Grid'
+import type { Vec3 } from '../types'
+
+type IntentHandler = (intent: string, payload: any) => void
+
+export class Interactor {
+  grid: Grid
+  dispatch: IntentHandler
+
+  constructor(grid: Grid, dispatch: IntentHandler) {
+    this.grid = grid
+    this.dispatch = dispatch
+  }
+
+  pointer(world: Vec3) {
+    const coord = this.grid.toCoord(world)
+    this.dispatch('pointer', { coord })
+  }
+}

--- a/src/3d/core/RenderPipeline.ts
+++ b/src/3d/core/RenderPipeline.ts
@@ -1,0 +1,20 @@
+import { WebGLRenderer, Scene, Camera } from 'three'
+
+export interface RenderPipeline {
+  createRenderer(): WebGLRenderer
+  render(renderer: WebGLRenderer, scene: Scene, camera: Camera, dt: number): void
+  mount?(scene: Scene, camera: Camera, renderer: WebGLRenderer): void
+  dispose?(): void
+}
+
+export class BasicPipeline implements RenderPipeline {
+  createRenderer() {
+    const r = new WebGLRenderer({ antialias: true })
+    r.setPixelRatio(globalThis.devicePixelRatio || 1)
+    return r
+  }
+
+  render(renderer: WebGLRenderer, scene: Scene, camera: Camera) {
+    renderer.render(scene, camera)
+  }
+}

--- a/src/3d/core/SceneController.ts
+++ b/src/3d/core/SceneController.ts
@@ -1,0 +1,57 @@
+import { Scene, PerspectiveCamera, WebGLRenderer } from 'three'
+import type { RenderPipeline } from './RenderPipeline'
+import { AssetStore } from './Assets/AssetStore'
+import type { Interactor } from './Interact/Interactor'
+import type { Grid } from '../grids/Grid'
+import type { Nav } from '../nav/Nav'
+
+interface SceneControllerOptions {
+  grid: Grid
+  nav: Nav
+  pipeline: RenderPipeline
+  assets?: AssetStore
+  interactor?: Interactor
+}
+
+export class SceneController {
+  scene: Scene
+  camera: PerspectiveCamera
+  renderer!: WebGLRenderer
+  grid: Grid
+  nav: Nav
+  pipeline: RenderPipeline
+  assets: AssetStore
+  interactor?: Interactor
+
+  constructor(opts: SceneControllerOptions) {
+    this.scene = new Scene()
+    this.camera = new PerspectiveCamera()
+    this.grid = opts.grid
+    this.nav = opts.nav
+    this.pipeline = opts.pipeline
+    this.assets = opts.assets || new AssetStore()
+    this.interactor = opts.interactor
+  }
+
+  init(container: HTMLElement) {
+    this.renderer = this.pipeline.createRenderer()
+    container.appendChild(this.renderer.domElement)
+    this.pipeline.mount?.(this.scene, this.camera, this.renderer)
+  }
+
+  tick(dt: number) {
+    this.pipeline.render(this.renderer, this.scene, this.camera, dt)
+  }
+
+  resize(width: number, height: number) {
+    this.renderer.setSize(width, height)
+    this.camera.aspect = width / height
+    this.camera.updateProjectionMatrix()
+  }
+
+  dispose() {
+    this.pipeline.dispose?.()
+    this.renderer.dispose()
+    this.assets.clear()
+  }
+}

--- a/src/3d/core/types.ts
+++ b/src/3d/core/types.ts
@@ -1,0 +1,10 @@
+export interface Vec2 {
+  x: number
+  y: number
+}
+
+export interface Vec3 {
+  x: number
+  y: number
+  z: number
+}

--- a/src/3d/grids/CoordConverters/README.md
+++ b/src/3d/grids/CoordConverters/README.md
@@ -1,0 +1,1 @@
+Placeholder for axial<->world and cartesian<->world coordinate conversion helpers.

--- a/src/3d/grids/Grid.ts
+++ b/src/3d/grids/Grid.ts
@@ -1,0 +1,11 @@
+import type { Vec2, Vec3 } from '../core/types'
+
+export interface Grid {
+  toWorld(coord: Vec2): Vec3
+  toCoord(world: Vec3): Vec2
+  neighbors(coord: Vec2): Vec2[]
+  distance(a: Vec2, b: Vec2): number
+  ring(center: Vec2, radius: number): Vec2[]
+  spiral(center: Vec2, radius: number): Vec2[]
+  raycastTileLine(a: Vec2, b: Vec2): Vec2[]
+}

--- a/src/3d/grids/HexGrid.ts
+++ b/src/3d/grids/HexGrid.ts
@@ -1,0 +1,97 @@
+import type { Vec2, Vec3 } from '../core/types'
+import type { Grid } from './Grid'
+
+function hexLerp(a: Vec2, b: Vec2, t: number): Vec2 {
+  return { x: a.x + (b.x - a.x) * t, y: a.y + (b.y - a.y) * t }
+}
+
+function hexRound(h: Vec2): Vec2 {
+  let x = h.x
+  let y = h.y
+  let z = -x - y
+  let rx = Math.round(x)
+  let ry = Math.round(y)
+  let rz = Math.round(z)
+  const xDiff = Math.abs(rx - x)
+  const yDiff = Math.abs(ry - y)
+  const zDiff = Math.abs(rz - z)
+  if (xDiff > yDiff && xDiff > zDiff) {
+    rx = -ry - rz
+  } else if (yDiff > zDiff) {
+    ry = -rx - rz
+  } else {
+    rz = -rx - ry
+  }
+  return { x: rx, y: ry }
+}
+
+export class HexGrid implements Grid {
+  size: number
+
+  constructor(size = 1) {
+    this.size = size
+  }
+
+  toWorld({ x, y }: Vec2): Vec3 {
+    const worldX = this.size * (Math.sqrt(3) * x + (Math.sqrt(3) / 2) * y)
+    const worldZ = this.size * (3 / 2) * y
+    return { x: worldX, y: 0, z: worldZ }
+  }
+
+  toCoord({ x, z }: Vec3): Vec2 {
+    const q = (Math.sqrt(3) / 3 * x - 1 / 3 * z) / this.size
+    const r = (2 / 3 * z) / this.size
+    return hexRound({ x: q, y: r })
+  }
+
+  neighbors(c: Vec2): Vec2[] {
+    const dirs = [
+      [1, 0],
+      [1, -1],
+      [0, -1],
+      [-1, 0],
+      [-1, 1],
+      [0, 1],
+    ]
+    return dirs.map((d) => ({ x: c.x + d[0], y: c.y + d[1] }))
+  }
+
+  distance(a: Vec2, b: Vec2): number {
+    const dx = a.x - b.x
+    const dy = a.y - b.y
+    const dz = -a.x - a.y - (-b.x - b.y)
+    return (Math.abs(dx) + Math.abs(dy) + Math.abs(dz)) / 2
+  }
+
+  ring(center: Vec2, radius: number): Vec2[] {
+    if (radius === 0) return [center]
+    const results: Vec2[] = []
+    let cube = { x: center.x + radius, y: center.y - radius }
+    for (let i = 0; i < 6; i++) {
+      for (let j = 0; j < radius; j++) {
+        results.push({ x: cube.x, y: cube.y })
+        const dir = this.neighbors({ x: 0, y: 0 })[i]
+        cube.x += dir.x
+        cube.y += dir.y
+      }
+    }
+    return results
+  }
+
+  spiral(center: Vec2, radius: number): Vec2[] {
+    let results: Vec2[] = [center]
+    for (let k = 1; k <= radius; k++) {
+      results = results.concat(this.ring(center, k))
+    }
+    return results
+  }
+
+  raycastTileLine(a: Vec2, b: Vec2): Vec2[] {
+    const N = this.distance(a, b)
+    const results: Vec2[] = []
+    for (let i = 0; i <= N; i++) {
+      results.push(hexRound(hexLerp(a, b, i / N)))
+    }
+    return results
+  }
+}

--- a/src/3d/grids/SquareGrid.ts
+++ b/src/3d/grids/SquareGrid.ts
@@ -1,0 +1,76 @@
+import type { Vec2, Vec3 } from '../core/types'
+import type { Grid } from './Grid'
+
+export class SquareGrid implements Grid {
+  size: number
+
+  constructor(size = 1) {
+    this.size = size
+  }
+
+  toWorld({ x, y }: Vec2): Vec3 {
+    return { x: x * this.size, y: 0, z: y * this.size }
+  }
+
+  toCoord({ x, z }: Vec3): Vec2 {
+    return { x: Math.round(x / this.size), y: Math.round(z / this.size) }
+  }
+
+  neighbors(c: Vec2): Vec2[] {
+    const dirs = [
+      [1, 0],
+      [-1, 0],
+      [0, 1],
+      [0, -1],
+    ]
+    return dirs.map((d) => ({ x: c.x + d[0], y: c.y + d[1] }))
+  }
+
+  distance(a: Vec2, b: Vec2): number {
+    return Math.abs(a.x - b.x) + Math.abs(a.y - b.y)
+  }
+
+  ring(center: Vec2, radius: number): Vec2[] {
+    const res: Vec2[] = []
+    for (let x = -radius; x <= radius; x++) res.push({ x: center.x + x, y: center.y - radius })
+    for (let y = -radius + 1; y < radius; y++) res.push({ x: center.x + radius, y: center.y + y })
+    for (let x = radius; x >= -radius; x--) res.push({ x: center.x + x, y: center.y + radius })
+    for (let y = radius - 1; y > -radius; y--) res.push({ x: center.x - radius, y: center.y + y })
+    return res
+  }
+
+  spiral(center: Vec2, radius: number): Vec2[] {
+    let res: Vec2[] = [center]
+    for (let r = 1; r <= radius; r++) res = res.concat(this.ring(center, r))
+    return res
+  }
+
+  raycastTileLine(a: Vec2, b: Vec2): Vec2[] {
+    const res: Vec2[] = []
+    let x = a.x
+    let y = a.y
+    const dx = Math.abs(b.x - a.x)
+    const dy = Math.abs(b.y - a.y)
+    const n = 1 + dx + dy
+    const xInc = b.x > a.x ? 1 : -1
+    const yInc = b.y > a.y ? 1 : -1
+    let error = dx - dy
+    let dx2 = dx * 2
+    let dy2 = dy * 2
+    for (let i = 0; i < n; i++) {
+      res.push({ x, y })
+      if (error > 0) {
+        x += xInc
+        error -= dy2
+      } else if (error < 0) {
+        y += yInc
+        error += dx2
+      } else {
+        x += xInc
+        y += yInc
+        error += dx2 - dy2
+      }
+    }
+    return res
+  }
+}

--- a/src/3d/nav/HexNav.ts
+++ b/src/3d/nav/HexNav.ts
@@ -1,0 +1,50 @@
+import type { Vec2 } from '../core/types'
+import { HexGrid } from '../grids/HexGrid'
+import type { Nav } from './Nav'
+
+function key(c: Vec2) {
+  return `${c.x},${c.y}`
+}
+
+export class HexNav implements Nav {
+  grid: HexGrid
+  blockers = new Set<string>()
+
+  constructor(grid: HexGrid) {
+    this.grid = grid
+  }
+
+  setBlocker(coord: Vec2, blocked: boolean) {
+    const k = key(coord)
+    if (blocked) this.blockers.add(k)
+    else this.blockers.delete(k)
+  }
+
+  cost() {
+    return 1
+  }
+
+  pathfind(start: Vec2, goal: Vec2): Vec2[] {
+    const frontier: Vec2[] = [start]
+    const came = new Map<string, Vec2 | null>()
+    came.set(key(start), null)
+    while (frontier.length) {
+      const current = frontier.shift() as Vec2
+      if (key(current) === key(goal)) break
+      for (const next of this.grid.neighbors(current)) {
+        const k = key(next)
+        if (this.blockers.has(k) || came.has(k)) continue
+        frontier.push(next)
+        came.set(k, current)
+      }
+    }
+    const path: Vec2[] = []
+    if (!came.has(key(goal))) return path
+    let cur: Vec2 | null = goal
+    while (cur) {
+      path.unshift(cur)
+      cur = came.get(key(cur)) || null
+    }
+    return path
+  }
+}

--- a/src/3d/nav/Nav.ts
+++ b/src/3d/nav/Nav.ts
@@ -1,0 +1,7 @@
+import type { Vec2 } from '../core/types'
+
+export interface Nav {
+  pathfind(start: Vec2, goal: Vec2): Vec2[]
+  cost(from: Vec2, to: Vec2): number
+  setBlocker(coord: Vec2, blocked: boolean): void
+}

--- a/src/3d/nav/SquareNav.ts
+++ b/src/3d/nav/SquareNav.ts
@@ -1,0 +1,50 @@
+import type { Vec2 } from '../core/types'
+import { SquareGrid } from '../grids/SquareGrid'
+import type { Nav } from './Nav'
+
+function key(c: Vec2) {
+  return `${c.x},${c.y}`
+}
+
+export class SquareNav implements Nav {
+  grid: SquareGrid
+  blockers = new Set<string>()
+
+  constructor(grid: SquareGrid) {
+    this.grid = grid
+  }
+
+  setBlocker(coord: Vec2, blocked: boolean) {
+    const k = key(coord)
+    if (blocked) this.blockers.add(k)
+    else this.blockers.delete(k)
+  }
+
+  cost() {
+    return 1
+  }
+
+  pathfind(start: Vec2, goal: Vec2): Vec2[] {
+    const frontier: Vec2[] = [start]
+    const came = new Map<string, Vec2 | null>()
+    came.set(key(start), null)
+    while (frontier.length) {
+      const current = frontier.shift() as Vec2
+      if (key(current) === key(goal)) break
+      for (const next of this.grid.neighbors(current)) {
+        const k = key(next)
+        if (this.blockers.has(k) || came.has(k)) continue
+        frontier.push(next)
+        came.set(k, current)
+      }
+    }
+    const path: Vec2[] = []
+    if (!came.has(key(goal))) return path
+    let cur: Vec2 | null = goal
+    while (cur) {
+      path.unshift(cur)
+      cur = came.get(key(cur)) || null
+    }
+    return path
+  }
+}

--- a/src/arena/ArenaScene.ts
+++ b/src/arena/ArenaScene.ts
@@ -1,0 +1,13 @@
+import { SceneController } from '../3d/core/SceneController'
+import { BasicPipeline } from '../3d/core/RenderPipeline'
+import { SquareGrid } from '../3d/grids/SquareGrid'
+import { SquareNav } from '../3d/nav/SquareNav'
+
+export class ArenaScene extends SceneController {
+  constructor() {
+    const grid = new SquareGrid(1)
+    const nav = new SquareNav(grid)
+    const pipeline = new BasicPipeline()
+    super({ grid, nav, pipeline })
+  }
+}

--- a/src/worldmap/WorldMapScene.ts
+++ b/src/worldmap/WorldMapScene.ts
@@ -1,0 +1,13 @@
+import { SceneController } from '../3d/core/SceneController'
+import { BasicPipeline } from '../3d/core/RenderPipeline'
+import { HexGrid } from '../3d/grids/HexGrid'
+import { HexNav } from '../3d/nav/HexNav'
+
+export class WorldMapScene extends SceneController {
+  constructor() {
+    const grid = new HexGrid(1)
+    const nav = new HexNav(grid)
+    const pipeline = new BasicPipeline()
+    super({ grid, nav, pipeline })
+  }
+}


### PR DESCRIPTION
## Summary
- document 3D refactor plan and shared interfaces
- add engine-agnostic core with grids and nav strategies
- stub world map and arena scenes using shared core

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6898f473fad88327b9c6abcc2a8baa4e