### PR TITLE
feat: add ocean elevation band

### DIFF
--- a/src/renderer/ChunkNeighborhood.js
+++ b/src/renderer/ChunkNeighborhood.js
@@ -320,7 +320,7 @@ export default class ChunkNeighborhood {
         const cell = this.world ? this.world.getCell(q, r) : null;
         if (__doSample) { __dtCell += ((typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now()) - __t0; }
         if (__doSample) { __t0 = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now(); __samples += 1; }
-  const isWater = !!(cell && (cell.biome === 'deepWater' || cell.biome === 'shallowWater'));
+  const isWater = !!(cell && (cell.biome === 'deepWater' || cell.biome === 'ocean' || cell.biome === 'shallowWater'));
   // Top center/scale via attributes
   const instIdx = startIdx + local;
   if (this._ctrArrTop && this._scyArrTop) {
@@ -415,7 +415,7 @@ export default class ChunkNeighborhood {
         if (__doSample) __t0 = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
         const cell = this.world ? this.world.getCell(q, r) : null;
         if (__doSample) task.__profSub.cell += ((typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now()) - __t0;
-        const isWater = !!(cell && (cell.biome === 'deepWater' || cell.biome === 'shallowWater'));
+        const isWater = !!(cell && (cell.biome === 'deepWater' || cell.biome === 'ocean' || cell.biome === 'shallowWater'));
         if (__doSample) { __t0 = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now(); }
         const instIdx = task.startIdx + st.local;
         // Write attribute center/scale

--- a/src/stores/arenaStore.js
+++ b/src/stores/arenaStore.js
@@ -113,7 +113,7 @@ export const useArenaStore = defineStore('arena', {
           const cell = world.getCell(x - half, y - half);
           terrain[x][y] = {
             terrain: {
-              passable: cell.biome !== 'deepWater' && cell.biome !== 'shallowWater',
+                passable: cell.biome !== 'deepWater' && cell.biome !== 'ocean' && cell.biome !== 'shallowWater',
               moisture: cell.f,
               flora: cell.f,
               color: `#${cell.colorTop.getHexString()}`,

--- a/src/terrain/biomes.js
+++ b/src/terrain/biomes.js
@@ -7,6 +7,7 @@ const palette = {
   // Water
   abyss: new THREE.Color('#052234'),   // darker blue
   deepWater: new THREE.Color('#0f3a59'),
+  ocean: new THREE.Color('#155e8b'),
   shallowWater: new THREE.Color('#1e6ea3'),
   shelfCyan: new THREE.Color('#11a6b8'),
   lagoon: new THREE.Color('#2fd6c7'),
@@ -42,6 +43,7 @@ export function classifyFoliage(f) {
 export function classifyBiome(h) {
   // Updated thresholds for stronger elevation contrast
   if (h < 0.05) return 'deepWater';
+  if (h < 0.08) return 'ocean';
   if (h < 0.12) return 'shallowWater';
   if (h < 0.20) return 'beach';
   if (h < 0.45) return 'lowland';
@@ -53,6 +55,7 @@ export function classifyBiome(h) {
 // Export thresholds so terrain generation / height shaping can reference them without duplication
 export const BIOME_THRESHOLDS = {
   deepWater: 0.05,
+  ocean: 0.08,
   shallowWater: 0.12,
   beach: 0.20,
   lowland: 0.45,
@@ -98,9 +101,15 @@ export function biomeColor(h, foliage, t, outColor = new THREE.Color(), opts = n
     hsl.l = Math.max(0, hsl.l * (1 - 0.30 * depth));
     deepSand.setHSL(hsl.h, hsl.s, hsl.l);
     outColor.copy(deepSand);
+  } else if (h < 0.08) {
+    // Open ocean: transition between abyss and shelf
+    const f = (h - 0.05) / 0.03; // 0.05-0.08
+    const deepSand = palette.desertTan.clone().lerp(palette.dune, 0.5);
+    const midSand = palette.desertTan.clone().lerp(palette.dune, 0.55);
+    outColor.copy(deepSand).lerp(midSand, f);
   } else if (h < 0.12) {
-    // Shallow water: lighter sandy seabed approaching beach
-    const f = (h - 0.05) / 0.07; // 0.05-0.12
+    // Shallow water over continental shelf
+    const f = (h - 0.08) / 0.04; // 0.08-0.12
     const nearSea = palette.desertTan.clone().lerp(palette.dune, 0.6);
     const nearBeach = palette.beach.clone().lerp(palette.dune, 0.35);
     outColor.copy(nearSea).lerp(nearBeach, Math.pow(f, 0.85));

--- a/src/views/primary/WorldMap.vue
+++ b/src/views/primary/WorldMap.vue
@@ -824,7 +824,7 @@ export default {
           const x = hexWidth * q;
           const z = hexHeight * (r + q / 2);
           const cell = this.world ? this.world.getCell(q, r) : null;
-          const isWater = !!(cell && (cell.biome === 'deepWater' || cell.biome === 'shallowWater'));
+          const isWater = !!(cell && (cell.biome === 'deepWater' || cell.biome === 'ocean' || cell.biome === 'shallowWater'));
           // Build matrix once and reuse for top/side with differing Y scale
           dummy.position.set(x, 0, z);
           dummy.rotation.set(0, 0, 0);
@@ -1709,7 +1709,7 @@ export default {
           const qW = q + qOrigin;
           const rW = r + rOrigin;
           const cell = this.world.getCell(qW, rW);
-          const isWater = cell && (cell.biome === 'deepWater' || cell.biome === 'shallowWater');
+          const isWater = cell && (cell.biome === 'deepWater' || cell.biome === 'ocean' || cell.biome === 'shallowWater');
           const v = isWater ? 0 : 255;
           data[i] = v; // R
           data[i + 1] = 0;
@@ -1780,7 +1780,7 @@ export default {
         const cell = this.world.getCell(q, r);
         const topY = this.hexMaxY * modelScaleY(q, r);
         if (topY < minTop) minTop = topY;
-        const isWater = cell && (cell.biome === 'deepWater' || cell.biome === 'shallowWater');
+        const isWater = cell && (cell.biome === 'deepWater' || cell.biome === 'ocean' || cell.biome === 'shallowWater');
         if (isWater) {
           if (topY < minTopWater) minTopWater = topY;
           waterCount += 1;
@@ -2296,7 +2296,7 @@ export default {
         if (!coord) continue;
         if (!landOnly || !this.world) return idx;
         const cell = this.world.getCell(coord.q, coord.r);
-        if (cell && cell.biome !== 'deepWater' && cell.biome !== 'shallowWater') return idx;
+        if (cell && cell.biome !== 'deepWater' && cell.biome !== 'ocean' && cell.biome !== 'shallowWater') return idx;
       }
       // Fallback
       return Math.floor(Math.random() * this.indexToQR.length);
@@ -2380,7 +2380,7 @@ export default {
       const x = hexW * q;
       const z = hexH * (r + q / 2);
       const cell = this.world.getCell(q, r);
-      const isWater = !!(cell && (cell.biome === 'deepWater' || cell.biome === 'shallowWater'));
+      const isWater = !!(cell && (cell.biome === 'deepWater' || cell.biome === 'ocean' || cell.biome === 'shallowWater'));
       const scaleY = isWater ? Math.max(0.001, 0.02 * (this.modelScaleFactor || 1)) : (this.modelScaleFactor * (cell ? cell.yScale : 1) * (this.heightMagnitude != null ? this.heightMagnitude : 1.0));
       const xzScale = (this.modelScaleFactor || 1) * this.contactScale * (bucket === 'side' ? (this.sideInset != null ? this.sideInset : 0.996) : 1.0);
       return { x, z, scaleY, xzScale };

--- a/src/world/ClutterManager.js
+++ b/src/world/ClutterManager.js
@@ -320,8 +320,8 @@ export default class ClutterManager {
         for (const typeDef of this.types) {
           const rule = biomeRules(typeDef);
           if (!rule) continue;
-          if (typeDef.id === 'tree_pine' && cell.biome !== 'deepWater' && cell.biome !== 'shallowWater') { if (temp > 0.45) continue; }
-          if (typeDef.id === 'tree_round' && cell.biome !== 'deepWater' && cell.biome !== 'shallowWater') { if (temp < 0.35) continue; }
+          if (typeDef.id === 'tree_pine' && cell.biome !== 'deepWater' && cell.biome !== 'ocean' && cell.biome !== 'shallowWater') { if (temp > 0.45) continue; }
+          if (typeDef.id === 'tree_round' && cell.biome !== 'deepWater' && cell.biome !== 'ocean' && cell.biome !== 'shallowWater') { if (temp < 0.35) continue; }
           const baseDensity = Math.max(0, (rule.density || 0) * this.densityMultiplier);
           const maxPerTile = Math.max(0, rule.maxPerTile || 0);
           if (baseDensity <= 0 || maxPerTile <= 0) continue;

--- a/src/world/WorldGrid.js
+++ b/src/world/WorldGrid.js
@@ -156,7 +156,7 @@ export default class WorldGrid {
     const blendRange = this.elevation.shorelineBlend;
   let yScale = baseScaleY;
     let biome = classifyBiome(hRaw);
-    if (biome !== 'deepWater' && biome !== 'shallowWater') {
+    if (biome !== 'deepWater' && biome !== 'ocean' && biome !== 'shallowWater') {
       if (hRaw <= shoreTop + blendRange) {
         const tt = (hRaw - shoreTop) / blendRange;
         const smoothT = tt <= 0 ? 0 : tt >= 1 ? 1 : (tt * tt * (3 - 2 * tt));

--- a/src/world/generation/HexWorldGenerator.js
+++ b/src/world/generation/HexWorldGenerator.js
@@ -91,7 +91,7 @@ function clamp01(x) { return x < 0 ? 0 : x > 1 ? 1 : x; }
 
 // Bands and enums
 export const ElevationBand = {
-  DeepOcean: 'DeepOcean', Shelf: 'Shelf', Coast: 'Coast', Lowland: 'Lowland', Highland: 'Highland', Mountain: 'Mountain', Peak: 'Peak',
+  DeepOcean: 'DeepOcean', Ocean: 'Ocean', Shelf: 'Shelf', Coast: 'Coast', Lowland: 'Lowland', Highland: 'Highland', Mountain: 'Mountain', Peak: 'Peak',
 };
 export const TemperatureBand = { Polar: 'Polar', Cold: 'Cold', Temperate: 'Temperate', Tropical: 'Tropical' };
 export const MoistureBand = { Arid: 'Arid', SemiArid: 'SemiArid', Humid: 'Humid', Saturated: 'Saturated' };
@@ -100,6 +100,7 @@ const ElevationThresholds = {
   // Sharper contrast per design doc v1.1
   // Deep ocean expanded, open seas wider, more interior highlands/mountains
   deep: 0.05,
+  ocean: 0.08,
   shelf: 0.12,
   coast: 0.20,
   low: 0.45,
@@ -109,6 +110,7 @@ const ElevationThresholds = {
 
 function classifyElevationBand(h) {
   if (h < ElevationThresholds.deep) return ElevationBand.DeepOcean;
+  if (h < ElevationThresholds.ocean) return ElevationBand.Ocean;
   if (h < ElevationThresholds.shelf) return ElevationBand.Shelf;
   if (h < ElevationThresholds.coast) return ElevationBand.Coast;
   if (h < ElevationThresholds.low) return ElevationBand.Lowland;


### PR DESCRIPTION
## Summary
- add Ocean band to elevation generation
- classify and shade open ocean in biome palette
- treat ocean cells as water across rendering and game logic

## Testing
- `npm run lint` (fails: 340 problems, pre-existing)

------
https://chatgpt.com/codex/tasks/task_e_68990d03dcac8327b54c8cdfd759ab7f