### PR TITLE
Replace water alpha blending with screen-space dithering

### DIFF
--- a/src/renderer/materials/RealisticWaterMaterial.js
+++ b/src/renderer/materials/RealisticWaterMaterial.js
@@ -236,7 +236,10 @@ export default function createRealisticWaterMaterial(options = {}) {
   alpha = max(alpha, bandsSolid);
   // Allow base water to render outside coverage for a continuous ocean; still hide the solid band outside
   alpha *= mix(1.0, covSoft * inside, step(0.5, waveMaskSolid));
-  gl_FragColor = vec4(col, alpha);
+  // Dither-based transparency: convert alpha to a stipple pattern in screen space
+  float dither = hash12(gl_FragCoord.xy);
+  if (alpha < dither) discard;
+  gl_FragColor = vec4(col, 1.0);
     }
   `;
 
@@ -244,8 +247,8 @@ export default function createRealisticWaterMaterial(options = {}) {
     uniforms,
     vertexShader,
     fragmentShader,
-    transparent: true,
-    depthWrite: false,
+    transparent: false,
+    depthWrite: true,
     depthTest: true,
   });
   return mat;

--- a/src/renderer/materials/SeaWavesMaterial.js
+++ b/src/renderer/materials/SeaWavesMaterial.js
@@ -124,8 +124,10 @@ export default function createSeaWavesMaterial(options = {}) {
       // Combine
       float crests = clamp(L1 * uStrength1 + L2 * uStrength2, 0.0, 1.0);
       vec3 color = mix(base, uFoam, crests);
-
-      gl_FragColor = vec4(color, uOpacity);
+      float alpha = clamp(uOpacity, 0.0, 1.0);
+      float dither = hash(gl_FragCoord.xy);
+      if (alpha < dither) discard;
+      gl_FragColor = vec4(color, 1.0);
     }
   `;
 
@@ -133,8 +135,8 @@ export default function createSeaWavesMaterial(options = {}) {
     uniforms,
     vertexShader,
     fragmentShader,
-    transparent: true,
-    depthWrite: false,
+    transparent: false,
+    depthWrite: true,
     depthTest: true,
     polygonOffset: true,
     polygonOffsetFactor: -1,

--- a/src/renderer/materials/StylizedWaterMaterial.js
+++ b/src/renderer/materials/StylizedWaterMaterial.js
@@ -277,7 +277,10 @@ export default function createStylizedWaterMaterial(options = {}) {
   vec3 col = mix(diffuse, uFoamCol, max(foam, bandsSolid));
       col += spec;
   // Alpha no longer hard-gated by coverage so water extends beyond neighborhood
-  gl_FragColor = vec4(col, uOpacity);
+  float alpha = clamp(uOpacity, 0.0, 1.0);
+  float dither = hash12(gl_FragCoord.xy);
+  if (alpha < dither) discard;
+  gl_FragColor = vec4(col, 1.0);
     }
   `;
 
@@ -285,8 +288,8 @@ export default function createStylizedWaterMaterial(options = {}) {
     uniforms,
     vertexShader,
     fragmentShader,
-    transparent: true,
-    depthWrite: false,
+    transparent: false,
+    depthWrite: true,
     depthTest: true,
   });
   return mat;


### PR DESCRIPTION
## Summary
- Use screen-space hash dithering to discard low-alpha water fragments
- Disable blending and enable depth writes so water occludes background

## Testing
- `npm run lint` *(fails: numerous existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689929637484832787d8b1845a6bc003