### PR TITLE
feat: plug-and-play world generation versions

### DIFF
--- a/src/3d/world/generation/index.js
+++ b/src/3d/world/generation/index.js
@@ -1,0 +1,30 @@
+import { createHexGenerator } from './HexWorldGenerator';
+
+// Registry of available world generator factories keyed by version name
+const registry = {
+  hex: createHexGenerator,
+};
+
+/**
+ * Return a list of available generator version keys.
+ */
+export function availableWorldGenerators() {
+  return Object.keys(registry);
+}
+
+/**
+ * Create a world generator for a given version and seed.
+ * Falls back to the default 'hex' generator when the version is unknown.
+ */
+export function createWorldGenerator(version = 'hex', seed) {
+  const factory = registry[version] || registry.hex;
+  return factory(seed);
+}
+
+/**
+ * Allow external registration of additional generator versions at runtime.
+ * Useful for experimentation with new algorithms.
+ */
+export function registerWorldGenerator(version, factory) {
+  if (version && typeof factory === 'function') registry[version] = factory;
+}

--- a/src/components/world/WorldDebugPanel.vue
+++ b/src/components/world/WorldDebugPanel.vue
@@ -116,6 +116,16 @@
       </summary>
       <div style="display: flex; flex-direction: column; gap: 6px; margin-top: 6px;">
         <div style="display: grid; grid-template-columns: auto 90px; gap: 4px 8px; align-items: center;">
+          <span style="opacity: 0.8; text-align: right;">Version</span>
+          <select
+            :value="genLocal.version"
+            style="width: 100%;"
+            @change="onSetGeneratorVersion($event)"
+          >
+            <option v-for="v in generatorVersions" :key="v" :value="v">{{ v }}</option>
+          </select>
+        </div>
+        <div style="display: grid; grid-template-columns: auto 90px; gap: 4px 8px; align-items: center;">
           <span style="opacity: 0.8; text-align: right;">Scale</span>
           <input
             :value="genLocal.scale"
@@ -291,6 +301,7 @@ export default {
     generation: { type: Object, required: true },
     benchmark: { type: Object, required: false },
   statsVisible: { type: Boolean, required: false, default: true },
+  generatorVersions: { type: Array, required: false, default: () => [] },
   },
   emits: [
     'update:features',
@@ -309,11 +320,14 @@ export default {
     'run-benchmark',
   // Gameplay actions
   'create-town',
+  'generator-version-change',
   ],
   computed: {
     featuresLocal() { return this.features || {}; },
     radialLocal() { return this.radialFade || {}; },
-  genLocal() { return this.generation || { scale: 1, tuning: {} }; },
+  genLocal() {
+      return this.generation || { scale: 1, tuning: {}, version: this.generatorVersions?.[0] };
+    },
   },
   methods: {
     fmt(v, n = 1) { if (v == null || Number.isNaN(v)) return '—'; const x = Number(v); return Math.abs(x) < 1e-6 ? '0' : x.toFixed(n); },
@@ -366,6 +380,12 @@ export default {
       this.$emit('set-neighborhood-radius', r);
     },
   // Removed legacy neighborhood expansion toggle
+    onSetGeneratorVersion(e) {
+      const version = e.target.value;
+      const next = { ...(this.genLocal || {}), version };
+      this.$emit('update:generation', next);
+      this.$emit('generator-version-change');
+    },
   },
 };
 </script>


### PR DESCRIPTION
## Summary
- add registry for world generator algorithms
- allow WorldGrid to swap generator versions with tuning
- expose generator version selector in debug panel and propagate changes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx eslint src/3d/world/generation/index.js src/3d/world/WorldGrid.js src/components/world/WorldDebugPanel.vue src/views/primary/WorldMap.vue` *(fails: empty block statement/no-unused-vars)*

------
https://chatgpt.com/codex/tasks/task_e_689a667722c083279cf45592e55ee935