### PR TITLE
Allow generator selection to change worlds

### DIFF
--- a/src/3d/world/WorldGrid.js
+++ b/src/3d/world/WorldGrid.js
@@ -74,7 +74,8 @@ export default class WorldGrid {
     if (!version || version === this.generatorVersion) return;
     this.generatorVersion = version;
     this.hexGen = createWorldGenerator(this.generatorVersion, this.seed);
-    if (this._generatorTuning && this.hexGen.setTuning) this.hexGen.setTuning(this._generatorTuning);
+    // Reset tuning so new generator's defaults take effect
+    this._generatorTuning = null;
     this.invalidateCache();
   }
 

--- a/src/views/primary/WorldMap.vue
+++ b/src/views/primary/WorldMap.vue
@@ -2563,7 +2563,8 @@ export default {
     onGeneratorVersionChange() {
       if (this.world && this.world.setGeneratorVersion) {
         this.world.setGeneratorVersion(this.generation.version);
-        if (this.generation.tuning) this.world.setGeneratorTuning(this.generation.tuning);
+        // Clear tuning so the new generator's defaults are used
+        this.generation.tuning = {};
         if (this.centerChunk) this.setCenterChunk(this.centerChunk.x, this.centerChunk.y, { forceRefill: true });
         this.buildWater();
         this.scheduleClutterCommit(0);


### PR DESCRIPTION
## Summary
- Reset world grid tuning when switching generator versions so default settings apply
- Clear custom tuning in WorldMap so new generator defaults aren't overridden

## Testing
- `npm run lint` *(fails: 176 problems)*

------
https://chatgpt.com/codex/tasks/task_e_689a74e9a69883278474479aab918ce2