### PR TITLE
fix: sync world map seed with pinia store

### DIFF
--- a/src/views/primary/WorldMap.vue
+++ b/src/views/primary/WorldMap.vue
@@ -250,15 +250,18 @@ export default {
       const ch = this.chunkForAxial ? this.chunkForAxial(q, r) : { wx: null, wy: null };
       return { q, r, world: { x, z }, col: off.col, row: off.row, wx: ch.wx, wy: ch.wy, cell };
     },
-    worldSeed() {
-      // Replace with your actual logic for the world seed
-      return this.$store?.state?.worldSeed || null;
-    },
   },
   mounted() {
     // pinia stores
     this.settings = useSettingsStore();
   this.worldStore = useWorldStore();
+    this.$watch(
+      () => this.worldStore?.worldSeed,
+      (seed) => {
+        if (typeof seed === 'number') this.worldSeed = seed;
+      },
+      { immediate: true },
+    );
     // Startup marker for this view
     try {
       if (typeof window !== 'undefined') {


### PR DESCRIPTION
## Summary
- watch Pinia world store for world seed changes
- remove redundant computed property to prevent assignment issues

## Testing
- `npm run lint` *(fails: Empty block statement, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689acd1ea4448327b1ec578ba4341b68