### PR TITLE
Fix stuck rotation when pointer leaves world map

### DIFF
--- a/src/views/primary/WorldMap.vue
+++ b/src/views/primary/WorldMap.vue
@@ -2269,8 +2269,10 @@ export default {
         if (this.hoverMesh) this.hoverMesh.visible = false;
       }
     },
-    onPointerUp(event) {
-      if (event.button === 2) this.rotating = false;
+    onPointerUp() {
+      // Ensure rotation stops on pointerup or when the pointer leaves the scene
+      // (pointerleave events don't report the original button).
+      this.rotating = false;
     },
     scheduleChunkRecentering(wx, wy, delayMs = 3000) {
       // Currently we spawn new chunks immediately via setCenterChunk.


### PR DESCRIPTION
## Summary
- Ensure world map rotation stops when the pointer leaves or is released

## Testing
- `npm run lint` *(fails: 196 problems (147 errors, 49 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_689acd1ea4448327b1ec578ba4341b68