### PR TITLE
refactor: replace inline styles with Vuetify classes

### DIFF
--- a/src/components/general/StatsWindow.vue
+++ b/src/components/general/StatsWindow.vue
@@ -1,7 +1,7 @@
 <template>
   <v-card
-    class="stats-window"
-    style="position: absolute; right: 12px; top: 32px; z-index: 10; min-width: 320px; max-width: 420px;"
+    class="stats-window position-absolute"
+    style="right: 12px; top: 32px; z-index: 10; min-width: 320px; max-width: 420px;"
   >
     <v-tabs
       v-model="tab"

--- a/src/components/general/WorldBenchmarkPanel.vue
+++ b/src/components/general/WorldBenchmarkPanel.vue
@@ -1,7 +1,7 @@
 <template>
   <div
-    class="world-benchmark-panel"
-    style="position: absolute; bottom: 6px; left: 6px; width: 440px; height: 320px; padding: 8px 12px; background: rgba(0,0,0,0.55); color: #fff; border-radius: 6px; font-size: 12px; line-height: 1.2; pointer-events: auto; z-index: 20; display: block; box-shadow: 0 2px 8px rgba(0,0,0,0.18); overflow-x: auto; overflow-y: auto;"
+    class="world-benchmark-panel position-absolute text-white py-2 px-3 rounded text-caption overflow-auto"
+    style="bottom: 6px; left: 6px; width: 440px; height: 320px; background: rgba(0,0,0,0.55); pointer-events: auto; z-index: 20; display: block; box-shadow: 0 2px 8px rgba(0,0,0,0.18); line-height: 1.2;"
     @pointerdown.stop
     @mousedown.stop
     @click.stop

--- a/src/components/world/TileInfoPanel.vue
+++ b/src/components/world/TileInfoPanel.vue
@@ -1,7 +1,7 @@
 <template>
   <div
-    style="background: rgba(0,0,0,0.55); color: #fff; padding: 8px 10px; border-radius: 6px; min-width: 240px; max-width: 320px; font-size: 12px; line-height: 1.35;"
-    class="d-flex flex-column"
+    class="d-flex flex-column text-white py-2 px-3 rounded text-caption"
+    style="background: rgba(0,0,0,0.55); min-width: 240px; max-width: 320px; line-height: 1.35;"
   >
     <div class="text-h6 mb-2" style="font-size: 16px; font-weight: 600; letter-spacing: 0.5px;">
       Current Tile

--- a/src/components/world/WorldDebugPanel.vue
+++ b/src/components/world/WorldDebugPanel.vue
@@ -1,6 +1,7 @@
 <template>
   <div
-    style="position: absolute; right: 6px; top: 28px; z-index: 2; background: rgba(0,0,0,0.55); color: #fff; padding: 8px 10px; border-radius: 6px; min-width: 220px; font-size: 12px; line-height: 1.2;"
+    class="position-absolute text-white py-2 px-3 rounded text-caption"
+    style="right: 6px; top: 28px; z-index: 2; background: rgba(0,0,0,0.55); min-width: 220px; line-height: 1.2;"
     @pointerdown.stop
     @pointermove.stop
     @pointerup.stop
@@ -13,7 +14,10 @@
       open
       style="margin: 0 0 6px 0;"
     >
-      <summary style="cursor: pointer; user-select: none; outline: none; display: flex; align-items: center; gap: 8px; justify-content: space-between;">
+      <summary
+        class="cursor-pointer user-select-none d-flex align-center ga-2 justify-space-between"
+        style="outline: none;"
+      >
         <span>Rendering</span>
         <button
           style="background: rgba(255,255,255,0.12); color: #fff; border: 1px solid rgba(255,255,255,0.25); padding: 2px 6px; border-radius: 4px; font-size: 12px; cursor: pointer;"
@@ -22,48 +26,48 @@
           {{ statsVisible ? 'Hide Stats' : 'Show Stats' }}
         </button>
       </summary>
-      <div style="display: flex; flex-direction: column; gap: 6px; margin-top: 6px; align-items: stretch;">
+        <div class="d-flex flex-column align-stretch" style="gap: 6px; margin-top: 6px;">
         <div
           v-if="benchmark?.running"
-          style="opacity: 0.8; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;"
+          class="opacity-80 text-mono"
         >
           Benchmark running… 10s avg
         </div>
         <div
           v-else-if="benchmark?.result"
-          style="opacity: 0.9; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;"
+          class="opacity-90 text-mono"
         >
           10s avg: {{ fmt(benchmark.result.avg, 1) }} FPS (min {{ fmt(benchmark.result.min, 1) }}, max {{ fmt(benchmark.result.max, 1) }})
         </div>
 
         <!-- Feature toggles in compact grid -->
         <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 4px 10px;">
-          <label style="display: flex; align-items: center; gap: 6px; cursor: pointer;"><input
+            <label class="d-flex align-center cursor-pointer" style="gap: 6px;"><input
             type="checkbox"
             :checked="featuresLocal.clutter"
             @change="onToggleFeature('clutter', $event)"
           > Clutter</label>
-          <label style="display: flex; align-items: center; gap: 6px; cursor: pointer;"><input
+            <label class="d-flex align-center cursor-pointer" style="gap: 6px;"><input
             type="checkbox"
             :checked="featuresLocal.shadows"
             @change="onToggleFeature('shadows', $event)"
           > Shadows</label>
-          <label style="display: flex; align-items: center; gap: 6px; cursor: pointer;"><input
+            <label class="d-flex align-center cursor-pointer" style="gap: 6px;"><input
             type="checkbox"
             :checked="featuresLocal.water"
             @change="onToggleFeature('water', $event)"
           > Water</label>
-          <label style="display: flex; align-items: center; gap: 6px; cursor: pointer;"><input
+            <label class="d-flex align-center cursor-pointer" style="gap: 6px;"><input
             type="checkbox"
             :checked="featuresLocal.chunkColors"
             @change="onToggleFeature('chunkColors', $event)"
           > Chunk colors</label>
-          <label style="display: flex; align-items: center; gap: 6px; cursor: pointer;"><input
+            <label class="d-flex align-center cursor-pointer" style="gap: 6px;"><input
             type="checkbox"
             :checked="radialLocal.enabled"
             @change="onToggleRadialFade($event)"
           > Radial fade</label>
-          <label style="display: flex; align-items: center; gap: 6px; cursor: pointer;"><input
+            <label class="d-flex align-center cursor-pointer" style="gap: 6px;"><input
             type="checkbox"
             :checked="featuresLocal.directions"
             @change="onToggleFeature('directions', $event)"
@@ -72,35 +76,35 @@
 
         <!-- Radial fade controls (compact grid) -->
         <div style="display: grid; grid-template-columns: auto 90px; gap: 4px 8px; align-items: center; margin-top: 6px;">
-          <span style="opacity: 0.8; text-align: right;">Fade radius</span>
-          <input
-            :value="radialLocal.radius"
-            type="number"
-            step="0.5"
-            :disabled="!radialLocal.enabled"
-            style="width: 100%;"
-            @input="onSetRadial('radius', $event)"
-          >
-          <span style="opacity: 0.8; text-align: right;">Fade width</span>
-          <input
-            :value="radialLocal.width"
-            type="number"
-            step="0.25"
-            :disabled="!radialLocal.enabled"
-            style="width: 100%;"
-            @input="onSetRadial('width', $event)"
-          >
-          <span style="opacity: 0.8; text-align: right;">Min height</span>
-          <input
-            :value="radialLocal.minHeightScale"
-            type="number"
-            min="0"
-            max="0.5"
-            step="0.01"
-            :disabled="!radialLocal.enabled"
-            style="width: 100%;"
-            @input="onSetRadial('minHeightScale', $event)"
-          >
+            <span class="opacity-80 text-right">Fade radius</span>
+            <input
+              :value="radialLocal.radius"
+              type="number"
+              step="0.5"
+              :disabled="!radialLocal.enabled"
+              class="w-100"
+              @input="onSetRadial('radius', $event)"
+            >
+            <span class="opacity-80 text-right">Fade width</span>
+            <input
+              :value="radialLocal.width"
+              type="number"
+              step="0.25"
+              :disabled="!radialLocal.enabled"
+              class="w-100"
+              @input="onSetRadial('width', $event)"
+            >
+            <span class="opacity-80 text-right">Min height</span>
+            <input
+              :value="radialLocal.minHeightScale"
+              type="number"
+              min="0"
+              max="0.5"
+              step="0.01"
+              :disabled="!radialLocal.enabled"
+              class="w-100"
+              @input="onSetRadial('minHeightScale', $event)"
+            >
         </div>
       </div>
     </details>
@@ -110,35 +114,38 @@
       open
       style="margin: 8px 0 0 0;"
     >
-      <summary style="cursor: pointer; user-select: none; outline: none; display: flex; align-items: center; gap: 8px; justify-content: space-between;">
+      <summary
+        class="cursor-pointer user-select-none d-flex align-center ga-2 justify-space-between"
+        style="outline: none;"
+      >
         <span>Generation</span>
-        <span style="opacity: 0.8;">{{ Number(genLocal.scale).toFixed(2) }}×</span>
+        <span class="opacity-80">{{ Number(genLocal.scale).toFixed(2) }}×</span>
       </summary>
-      <div style="display: flex; flex-direction: column; gap: 6px; margin-top: 6px;">
+      <div class="d-flex flex-column" style="gap: 6px; margin-top: 6px;">
         <div style="display: grid; grid-template-columns: auto 90px; gap: 4px 8px; align-items: center;">
-          <span style="opacity: 0.8; text-align: right;">Version</span>
-          <select
-            :value="genLocal.version"
-            style="width: 100%;"
-            @change="onSetGeneratorVersion($event)"
-          >
+            <span class="opacity-80 text-right">Version</span>
+            <select
+              :value="genLocal.version"
+              class="w-100"
+              @change="onSetGeneratorVersion($event)"
+            >
             <option v-for="v in generatorVersions" :key="v" :value="v">{{ v }}</option>
           </select>
         </div>
         <div style="display: grid; grid-template-columns: auto 90px; gap: 4px 8px; align-items: center;">
-          <span style="opacity: 0.8; text-align: right;">Scale</span>
-          <input
-            :value="genLocal.scale"
-            type="number"
-            step="0.01"
-            style="width: 100%;"
-            @input="onSetGenerationScale($event)"
-          >
+            <span class="opacity-80 text-right">Scale</span>
+            <input
+              :value="genLocal.scale"
+              type="number"
+              step="0.01"
+              class="w-100"
+              @input="onSetGenerationScale($event)"
+            >
         </div>
 
         <!-- Map size (absolute radius) -->
         <div style="display: grid; grid-template-columns: auto 1fr; gap: 4px 8px; align-items: center;">
-          <span style="opacity: 0.8; text-align: right;">Map size</span>
+            <span class="opacity-80 text-right">Map size</span>
           <div style="display: flex; gap: 6px; flex-wrap: wrap;">
             <button
               :disabled="genLocal.radius === 1"
@@ -171,98 +178,98 @@
           </div>
         </div>
         <div style="display: grid; grid-template-columns: auto 90px; gap: 4px 8px; align-items: center;">
-          <span style="opacity: 0.8; text-align: right;">Neighborhood radius</span>
-          <input
-            :value="genLocal.radius ?? 1"
-            type="number"
-            min="1"
-            step="1"
-            style="width: 100%;"
-            @change="onSetNeighborhoodRadius($event)"
-          >
-          <div style="grid-column: 1 / span 2; opacity: 0.8;">
-            <span>Renders {{ (2 * (genLocal.radius ?? 1) + 1) }}×{{ (2 * (genLocal.radius ?? 1) + 1) }} chunks</span>
-          </div>
+            <span class="opacity-80 text-right">Neighborhood radius</span>
+            <input
+              :value="genLocal.radius ?? 1"
+              type="number"
+              min="1"
+              step="1"
+              class="w-100"
+              @change="onSetNeighborhoodRadius($event)"
+            >
+            <div class="opacity-80" style="grid-column: 1 / span 2;">
+              <span>Renders {{ (2 * (genLocal.radius ?? 1) + 1) }}×{{ (2 * (genLocal.radius ?? 1) + 1) }} chunks</span>
+            </div>
         </div>
 
         <!-- Collapse advanced tuning for compactness -->
         <details style="margin-top: 2px;">
-          <summary style="cursor: pointer; user-select: none; outline: none; opacity: 0.85;">
+          <summary class="cursor-pointer user-select-none" style="outline: none; opacity: 0.85;">
             Noise tuning (debug)
           </summary>
           <div style="display: grid; grid-template-columns: auto 90px; gap: 4px 8px; align-items: center; margin-top: 6px;">
-            <label style="opacity:0.8; text-align:right;">Continent</label>
+            <label class="opacity-80 text-right">Continent</label>
             <input
               :value="genLocal.tuning.continentScale"
               type="number"
               step="0.01"
-              style="width:100%;"
+              class="w-100"
               @input="onSetTuning('continentScale', $event)"
             >
-            <label style="opacity:0.8; text-align:right;">Warp</label>
+            <label class="opacity-80 text-right">Warp</label>
             <input
               :value="genLocal.tuning.warpScale"
               type="number"
               step="0.01"
-              style="width:100%;"
+              class="w-100"
               @input="onSetTuning('warpScale', $event)"
             >
-            <label style="opacity:0.8; text-align:right;">Warp strength</label>
+            <label class="opacity-80 text-right">Warp strength</label>
             <input
               :value="genLocal.tuning.warpStrength"
               type="number"
               step="0.01"
-              style="width:100%;"
+              class="w-100"
               @input="onSetTuning('warpStrength', $event)"
             >
-            <label style="opacity:0.8; text-align:right;">Plate size</label>
+            <label class="opacity-80 text-right">Plate size</label>
             <input
               :value="genLocal.tuning.plateSize"
               type="number"
               step="0.01"
-              style="width:100%;"
+              class="w-100"
               @input="onSetTuning('plateSize', $event)"
             >
-            <label style="opacity:0.8; text-align:right;">Ridge</label>
+            <label class="opacity-80 text-right">Ridge</label>
             <input
               :value="genLocal.tuning.ridgeScale"
               type="number"
               step="0.01"
-              style="width:100%;"
+              class="w-100"
               @input="onSetTuning('ridgeScale', $event)"
             >
-            <label style="opacity:0.8; text-align:right;">Detail</label>
+            <label class="opacity-80 text-right">Detail</label>
             <input
               :value="genLocal.tuning.detailScale"
               type="number"
               step="0.01"
-              style="width:100%;"
+              class="w-100"
               @input="onSetTuning('detailScale', $event)"
             >
-            <label style="opacity:0.8; text-align:right;">Climate belt</label>
+            <label class="opacity-80 text-right">Climate belt</label>
             <input
               :value="genLocal.tuning.climateScale"
               type="number"
               step="0.01"
-              style="width:100%;"
+              class="w-100"
               @input="onSetTuning('climateScale', $event)"
             >
-            <span style="opacity:0.8; text-align:right;">Ocean encaps.</span>
+            <span class="opacity-80 text-right">Ocean encaps.</span>
             <input
               :value="genLocal.tuning.oceanEncapsulation"
               type="number"
               step="0.01"
               min="0"
               max="1"
-              style="width:100%;"
+              class="w-100"
               @input="onSetTuning('oceanEncapsulation', $event)"
             >
-            <span style="opacity:0.8; text-align:right;">Sea bias</span>
+            <span class="opacity-80 text-right">Sea bias</span>
             <input
               :value="genLocal.tuning.seaBias"
               type="number"
               step="0.01"
-              style="width:100%;"
+              class="w-100"
               @input="onSetTuning('seaBias', $event)"
             >
           </div>
@@ -277,10 +284,10 @@
       open
       style="margin: 8px 0 0 0;"
     >
-      <summary style="cursor: pointer; user-select: none; outline: none;">
-        Actions
-      </summary>
-      <div style="display: flex; gap: 6px; margin-top: 6px; flex-wrap: wrap;">
+        <summary class="cursor-pointer user-select-none" style="outline: none;">
+          Actions
+        </summary>
+        <div class="d-flex flex-wrap" style="gap: 6px; margin-top: 6px;">
         <button
           style="background: rgba(255,255,255,0.12); color: #fff; border: 1px solid rgba(255,255,255,0.25); padding: 4px 8px; border-radius: 4px; font-size: 12px; cursor: pointer;"
           @click.stop.prevent="$emit('create-town')"

--- a/src/views/primary/WorldMap.vue
+++ b/src/views/primary/WorldMap.vue
@@ -1,14 +1,14 @@
 <template>
   <div
     ref="sceneContainer"
-    class="world-map"
-    style="position: relative; width: 100%; height: 100vh;"
+    class="world-map position-relative w-100 h-screen"
   >
     <!-- Current tile panel (left) -->
     <TileInfoPanel
       :tile="currentTileInfo"
       :seed="worldSeed"
-      style="position: absolute; left: 6px; top: 28px; z-index: 3; min-width: 240px; max-width: 320px;"
+      class="position-absolute"
+      style="left: 6px; top: 28px; z-index: 3; min-width: 240px; max-width: 320px;"
     />
     <!-- Debug overlay -->
     <WorldDebugPanel
@@ -19,7 +19,8 @@
       :benchmark="benchmark"
       :stats-visible="profilerEnabled"
       :generator-versions="generatorVersions"
-      style="position: absolute; right: 6px; top: 28px;"
+      class="position-absolute"
+      style="right: 6px; top: 28px;"
       @update:features="features = $event"
       @update:radialFade="radialFade = $event"
       @update:generation="generation = $event"


### PR DESCRIPTION
## Summary
- move common inline styles to Vuetify utility classes
- clean up TileInfoPanel, world panels, and WorldMap layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 148 errors, 130 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689b8964992883279f44f85ac825fcfe