### PR TITLE
Add water benchmark tab and metrics

### DIFF
--- a/src/components/general/WorldBenchmarkPanel.vue
+++ b/src/components/general/WorldBenchmarkPanel.vue
@@ -26,6 +26,12 @@
       >
         Chunk
       </v-tab>
+      <v-tab
+        value="water"
+        style="min-width: 60px; height: 24px; padding: 0 8px; font-size: 11px;"
+      >
+        Water
+      </v-tab>
     </v-tabs>
     <div
       v-if="tab === 'general'"
@@ -39,6 +45,12 @@
     >
       <pre style="white-space: pre-wrap; word-break: break-word;">{{ chunkStatsDisplay }}</pre>
     </div>
+    <div
+      v-else-if="tab === 'water'"
+      class="pa-2"
+    >
+      <pre style="white-space: pre-wrap; word-break: break-word;">{{ waterStatsDisplay }}</pre>
+    </div>
   </div>
 </template>
 
@@ -49,6 +61,7 @@ export default {
   props: {
     generalStats: { type: [String, Object], default: '' },
     chunkStats: { type: [String, Object], default: '' },
+    waterStats: { type: [String, Object], default: '' },
   },
   data() {
     return {
@@ -67,11 +80,9 @@ export default {
       lines.push(this.fmtStat(s.render, 'Render'));
       lines.push(this.fmtStat(s.fadeU, 'FadeU'));
       lines.push(this.fmtStat(s.tween, 'Tween'));
-      lines.push(this.fmtStat(s.waterU, 'WaterU'));
       lines.push(this.fmtStat(s.stream, 'Stream'));
       lines.push(this.fmtStat(s.slice, 'Slice'));
       lines.push(this.fmtStat(s.clutter, 'Clutter'));
-      lines.push(this.fmtStat(s.water, 'Water'));
       if (s.queueTotal) lines.push(`Queue Total: ${s.queueTotal.last ?? s.queueTotal.avg}`);
       if (s.queueRate) lines.push(`Queue Rate: ${(s.queueRate.last ?? 0).toFixed(1)}t/s`);
       if (s.queueEta) lines.push(`Queue ETA: ${s.queueEta.last ?? s.queueEta.avg}`);
@@ -96,6 +107,17 @@ export default {
       if (s.instCount != null && s.instTarget != null) lines.push(`Instances: ${s.instCount}/${s.instTarget}`);
       return lines.join('\n');
     },
+    waterStatsDisplay() {
+      if (!this.liveStats) return this.waterStats;
+      const s = this.liveStats;
+      const lines = [];
+      lines.push(this.fmtStat(s.waterU, 'Uniform'));
+      lines.push(this.fmtStat(s.water, 'Build'));
+      if (s.waterTexSize) lines.push(`Tex: ${s.waterTexSize}²`);
+      if (s.waterPlaneW && s.waterPlaneH) lines.push(`Plane: ${Math.round(s.waterPlaneW)}x${Math.round(s.waterPlaneH)}`);
+      if (s.waterTiles != null) lines.push(`Tiles: ${s.waterTiles}`);
+      return lines.join('\n');
+    },
   },
   watch: {
     tab(newTab) {
@@ -108,7 +130,7 @@ export default {
     this.settings = useSettingsStore?.() ?? null;
     if (this.settings && this.settings.get) {
       const val = this.settings.get('benchmarkPanelTab', null);
-      if (val === 'chunk' || val === 'general') this.tab = val;
+      if (val === 'chunk' || val === 'general' || val === 'water') this.tab = val;
     }
   },
   methods: {


### PR DESCRIPTION
## Summary
- Add Water tab to WorldBenchmarkPanel and remove water stats from General tab
- Instrument water build to gather texture size, plane dimensions, tile count, and build time
- Surface new water metrics via WorldMap and benchmark panel

## Testing
- `npm run lint` *(fails: Empty block statements and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689b926501b883279dfb349642a3cc1b