### PR TITLE
Use world coordinates for worldgen RNG seeding

### DIFF
--- a/shared/lib/worldgen/index.js
+++ b/shared/lib/worldgen/index.js
@@ -5,6 +5,7 @@
 import { DEFAULT_CONFIG } from './config.js';
 import { create as createRng } from './rng.js';
 import * as noise from './noiseUtils.js';
+import { axialToXZ } from '../../../client/src/3d2/config/layout.js';
 import { computeTilePart as layer00Compute } from './layers/layer00_palette.js';
 import { computeTilePart as layer01Compute, fallback as layer01Fallback } from './layers/layer01_continents.js';
 import { computeTilePart as layer02Compute } from './layers/layer02_regions.js';
@@ -32,7 +33,8 @@ function normalizeConfig(partial) {
 
 function generateTile(seed, q, r, cfgPartial) {
   const cfg = normalizeConfig(cfgPartial);
-  const ctx = { seed: String(seed), q, r, cfg, rng: createRng(seed, q, r), noise };
+  const { x, z } = axialToXZ(q, r, { layoutRadius: 1, spacingFactor: 1 });
+  const ctx = { seed: String(seed), q, r, x, z, cfg, rng: createRng(seed, x, z), noise };
 
   // run layers in order; parts are partial tile outputs consumed by later layers
   const parts = {};

--- a/shared/lib/worldgen/layers/layer02_regions.js
+++ b/shared/lib/worldgen/layers/layer02_regions.js
@@ -12,8 +12,8 @@ function pickArchetype(ctx, v) {
 
 function computeTilePart(ctx) {
   const scale = ctx.cfg.layers.layer2.regionNoiseScale || 0.02;
-  const v = fbm(ctx, ctx.q * scale, ctx.r * scale, 3);
-  const regionId = Math.abs(Math.floor((ctx.q * 31 + ctx.r * 17 + Math.floor(v * 1000))));
+  const v = fbm(ctx, ctx.x * scale, ctx.z * scale, 3);
+  const regionId = Math.abs(Math.floor((ctx.x * 31 + ctx.z * 17 + Math.floor(v * 1000))));
   const archetype = pickArchetype(ctx, v);
   return { region: { id: regionId, archetype } };
 }

--- a/shared/lib/worldgen/layers/layer03_biomes.js
+++ b/shared/lib/worldgen/layers/layer03_biomes.js
@@ -16,12 +16,12 @@ function chooseMajor(ctx, h) {
 }
 
 function computeTilePart(ctx) {
-  const h = (ctx.partials && ctx.partials.layer1 && ctx.partials.layer1.elevation) ? ctx.partials.layer1.elevation.normalized : fbm(ctx, ctx.q * 0.01, ctx.r * 0.01, 3);
+  const h = (ctx.partials && ctx.partials.layer1 && ctx.partials.layer1.elevation) ? ctx.partials.layer1.elevation.normalized : fbm(ctx, ctx.x * 0.01, ctx.z * 0.01, 3);
   const major = chooseMajor(ctx, h);
   // pick a secondary candidate with a small noise weight for blending
-  const secIdx = Math.floor(fbm(ctx, ctx.q * 0.03, ctx.r * 0.03, 2) * MAJOR.length) % MAJOR.length;
+  const secIdx = Math.floor(fbm(ctx, ctx.x * 0.03, ctx.z * 0.03, 2) * MAJOR.length) % MAJOR.length;
   const secondary = MAJOR[secIdx];
-  const blend = Math.abs(valueNoise(ctx, ctx.q * 0.07, ctx.r * 0.07) - 0.5) * 2 * 0.5; // 0..0.5
+  const blend = Math.abs(valueNoise(ctx, ctx.x * 0.07, ctx.z * 0.07) - 0.5) * 2 * 0.5; // 0..0.5
   return { biome: { major, secondary, blend } };
 }
 

--- a/shared/lib/worldgen/layers/layer04_specials.js
+++ b/shared/lib/worldgen/layers/layer04_specials.js
@@ -6,7 +6,7 @@ import { fbm } from '../noiseUtils.js';
 const SPECIALS = ['frozen_jungle','volcanic_seafloor','glass_desert','obsidian_flats','mushroom_glade'];
 
 function computeTilePart(ctx) {
-  const v = fbm(ctx, ctx.q * 0.002, ctx.r * 0.002, 2);
+  const v = fbm(ctx, ctx.x * 0.002, ctx.z * 0.002, 2);
   // rarity threshold depends on rarityMultiplier
   const thr = 0.995 * (1 / (ctx.cfg.layers.layer4.rarityMultiplier || 1));
   if (v > thr) {

--- a/shared/lib/worldgen/noiseFactory.js
+++ b/shared/lib/worldgen/noiseFactory.js
@@ -18,8 +18,8 @@ try {
 // Create a seeded noise2D function per tile using our SeededRNG as the
 // random source. We return an object with noise2D(x,y) to match the
 // previous factory contract used by layers.
-export function makeSimplex(seed, q, r) {
-  const s = String(seed) + ':' + String(q) + ':' + String(r);
+export function makeSimplex(seed, x, z) {
+  const s = String(seed) + ':' + String(x) + ':' + String(z);
   let h = 0;
   for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) >>> 0;
   const lcg = new SeededRNG(h);

--- a/shared/lib/worldgen/rng.js
+++ b/shared/lib/worldgen/rng.js
@@ -2,7 +2,7 @@
 // Deterministic RNG helpers used by worldgen. We export two primitives:
 // - SeededRNG: a small LCG that matches the client implementation (useful as a
 //   random source for SimplexNoise or other libraries that expect a RNG).
-// - create(seed,q,r): a tile-scoped xorshift32-based random() helper used for
+// - create(seed,x,z): a tile-scoped xorshift32-based random() helper used for
 //   lightweight value-noise and deterministic choices.
 
 // --- Seeded LCG (client parity) ---
@@ -37,8 +37,8 @@ function xorshift32(seed) {
   };
 }
 
-function create(seed, q, r) {
-  const s = String(seed) + ':' + String(q) + ':' + String(r);
+function create(seed, x, z) {
+  const s = String(seed) + ':' + String(x) + ':' + String(z);
   const h = hashStringToInt(s);
   return { random: xorshift32(h) };
 }

--- a/shared/scripts/inspectLayer1Parts.js
+++ b/shared/scripts/inspectLayer1Parts.js
@@ -1,5 +1,6 @@
 import { fbm as fbmFactory, domainWarp } from '../lib/worldgen/noiseUtils.js';
 import { makeSimplex } from '../lib/worldgen/noiseFactory.js';
+import { axialToXZ } from '../../client/src/3d2/config/layout.js';
 import { getDefaultConfig } from '../lib/worldgen/index.js';
 
 function inspect(seed, qStart, qEnd, rStart, rEnd, cfgOverride = {}) {
@@ -10,7 +11,8 @@ function inspect(seed, qStart, qEnd, rStart, rEnd, cfgOverride = {}) {
     for (let r = rStart; r <= rEnd; r++) {
       const mycfg = cfg.layers.layer1 || {};
       const scale = mycfg.scale || 12.0;
-      const noise = makeSimplex(String(seed), q, r);
+      const { x, z } = axialToXZ(q, r, { layoutRadius: 1, spacingFactor: 1 });
+      const noise = makeSimplex(String(seed), x, z);
       // macro
       const macro = (function(){
         const x = q / (mycfg.plateCellSize || 48);
@@ -59,7 +61,8 @@ console.log('\nInspect with smaller detailWeight (0.12)');
 (function(){
   const cfg = getDefaultConfig();
   for (let q=-2;q<=2;q++) for (let r=-2;r<=2;r++) {
-    const noise = makeSimplex('parity-seed', q, r);
+    const { x, z } = axialToXZ(q, r, { layoutRadius: 1, spacingFactor: 1 });
+    const noise = makeSimplex('parity-seed', x, z);
     const scale = cfg.layers.layer1.scale || 12.0;
     const x = q / (cfg.layers.layer1.plateCellSize || 48);
     const y = r / (cfg.layers.layer1.plateCellSize || 48);


### PR DESCRIPTION
## Summary
- convert axial (q,r) to world (x,z) and expose on worldgen context
- seed per-tile RNG and noise samplers with x,z instead of q,r
- update region/biome/special layers to sample noise using ctx.x/ctx.z

## Testing
- `npm --prefix shared test -- --run`
- `npm --prefix server test`


------
https://chatgpt.com/codex/tasks/task_e_68aa9d281b9883278e0a8aec0d7605ee