### PR TITLE
feat: add world generator getByXZ helper

### DIFF
--- a/client/src/3d2/domain/world/generator.js
+++ b/client/src/3d2/domain/world/generator.js
@@ -1,6 +1,7 @@
 import * as worldGen from './index';
 import { makeEntity } from '../entities';
 import { SeededRNG } from '../seeded';
+import { axialToXZ } from '@/3d2/config/layout';
 
 // Simple deterministic placement helper that samples generator cells inside a
 // radius and places a small set of entities (towns) at spots with high elevation
@@ -17,7 +18,8 @@ function populateEntities(seed, radius) {
   const entities = [];
   for (let q = -radius; q <= radius; q++) {
     for (let r = Math.max(-radius, -q - radius); r <= Math.min(radius, -q + radius); r++) {
-      const cell = gen.get(q, r);
+      const { x, z } = axialToXZ(q, r);
+      const cell = gen.getByXZ(x, z);
       // heuristic: prefer low slope, mid elevation land
   // Accept tile-shaped cell or legacy fields wrapper
   const elev = (typeof cell.height === 'number') ? cell.height : (cell.elevation && typeof cell.elevation.normalized === 'number' ? cell.elevation.normalized : (cell.fields && cell.fields.h) || 0);

--- a/client/src/3d2/domain/world/index.js
+++ b/client/src/3d2/domain/world/index.js
@@ -9,4 +9,4 @@ export const createWorldGenerator = gen.createWorldGenerator;
 export const registerWorldGenerator = gen.registerWorldGenerator;
 
 // Intentionally minimal: consumers should treat the returned generator as an
-// opaque object with `get(q,r)` and optional `setTuning`.
+// opaque object with `getByXZ(x,z)` (and legacy `get(q,r)`) and optional `setTuning`.

--- a/client/src/3d2/domain/world/localGenerator.js
+++ b/client/src/3d2/domain/world/localGenerator.js
@@ -1,4 +1,5 @@
 import * as shared from '../../../../../shared/lib/worldgen/index.js';
+import { worldXZToAxial, roundAxial } from '../../config/layout.js';
 
 // Minimal adapter: return the shared Tile object directly. Consumers should
 // use the tile shape (tile.elevation, tile.height, tile.palette, etc.).
@@ -7,8 +8,14 @@ export const availableWorldGenerators = ['hex:shared'];
 export function createWorldGenerator(type = 'hex', seed = 'seed', opts = {}) {
   let cfg = opts || {};
   return {
+    // Deprecated: prefer getByXZ(x,z)
     get(q, r) {
       return shared.generateTile(seed, q, r, cfg);
+    },
+    getByXZ(x, z) {
+      const frac = worldXZToAxial(x, z, { layoutRadius: 1, spacingFactor: 1 });
+      const { q, r } = roundAxial(frac.q, frac.r);
+      return this.get(q, r);
     },
     setTuning(newOpts = {}) {
       cfg = Object.assign({}, cfg, newOpts);

--- a/client/src/3d2/renderer/ChunkManager.js
+++ b/client/src/3d2/renderer/ChunkManager.js
@@ -26,7 +26,7 @@ export default class ChunkManager {
     this.features = opts.features || {};
     this.heightMagnitude = opts.heightMagnitude != null ? opts.heightMagnitude : 1.0;
     this.centerChunk = { x: opts.centerChunk?.x ?? 0, y: opts.centerChunk?.y ?? 0 };
-  // optional generator for sampling cell data (expects get(q,r) -> cell)
+  // optional generator for sampling cell data (expects getByXZ(x,z) -> cell)
   this.generator = opts.generator || null;
 
     // callbacks
@@ -180,8 +180,10 @@ export default class ChunkManager {
       let topCol = new THREE.Color(0xeeeeee);
       let sideCol = new THREE.Color(0xcccccc);
       try {
-        if (this.generator && typeof this.generator.get === 'function') {
-          const tile = this.generator.get(p.q, p.r);
+        if (this.generator) {
+          let tile;
+          if (typeof this.generator.getByXZ === 'function') tile = this.generator.getByXZ(p.x, p.z);
+          else if (typeof this.generator.get === 'function') tile = this.generator.get(p.q, p.r);
           const bio = biomeFromCell(tile);
           // Expect tile shape: prefer tile.height, then tile.elevation.normalized
           let elev = 0;

--- a/client/src/3d2/scenes/WorldMapScene.js
+++ b/client/src/3d2/scenes/WorldMapScene.js
@@ -302,11 +302,13 @@ export class WorldMapScene {
           let topCol = new THREE.Color(0xeeeeee);
           let sideCol = new THREE.Color(0xcccccc);
           try {
-            if (gen && typeof gen.get === 'function') {
-              const cell = gen.get(p.q, p.r);
-          // derive elevation from the canonical tile shape first, fall back to legacy fields.h
-          let elev = 0;
-          if (cell && typeof cell.height === 'number') elev = cell.height;
+            if (gen) {
+              let cell;
+              if (typeof gen.getByXZ === 'function') cell = gen.getByXZ(p.x, p.z);
+              else if (typeof gen.get === 'function') cell = gen.get(p.q, p.r);
+              // derive elevation from the canonical tile shape first, fall back to legacy fields.h
+              let elev = 0;
+              if (cell && typeof cell.height === 'number') elev = cell.height;
           else if (cell && cell.elevation && typeof cell.elevation.normalized === 'number') elev = cell.elevation.normalized;
           yScale = Math.max(0.001, elev * 1.0);
           // biomeFromCell accepts tile-shaped cells (height/elevation) or legacy fields
@@ -367,11 +369,13 @@ export class WorldMapScene {
           let yScale = 1.0;
           let col = new THREE.Color(0xeeeeee);
           try {
-            if (gen && typeof gen.get === 'function') {
-              const cell = gen.get(p.q, p.r);
-          // prefer tile.height / elevation.normalized
-          let elev = 0;
-          if (cell && typeof cell.height === 'number') elev = cell.height;
+            if (gen) {
+              let cell;
+              if (typeof gen.getByXZ === 'function') cell = gen.getByXZ(p.x, p.z);
+              else if (typeof gen.get === 'function') cell = gen.get(p.q, p.r);
+              // prefer tile.height / elevation.normalized
+              let elev = 0;
+              if (cell && typeof cell.height === 'number') elev = cell.height;
           else if (cell && cell.elevation && typeof cell.elevation.normalized === 'number') elev = cell.elevation.normalized;
           yScale = Math.max(0.001, elev * 1.0);
           const bio = biomeFromCell(cell);


### PR DESCRIPTION
## Summary
- add getByXZ(x,z) convenience method to world generator
- switch entity population, chunk manager, and map scene to call getByXZ instead of get(q,r)
- document new API on domain world wrapper

## Testing
- `npm test`
- `npm --prefix server test`

------
https://chatgpt.com/codex/tasks/task_e_68aa9f1d2e808327af29a0b36f7f0989