### PR TITLE
refactor: add cell-based grid and nav

### DIFF
--- a/client/src/3d2/domain/nav/HexNav.js
+++ b/client/src/3d2/domain/nav/HexNav.js
@@ -1,5 +1,10 @@
-// Simple axial distance using cube coordinates (inline to avoid external imports)
-function distanceAxial(a, b) {
+// Pathfinding utilities for hex grids using cell indices or world positions.
+// Public API uses generic cell indices while axial conversions remain private.
+
+import { WorldGrid } from '../grid/WorldGrid';
+
+// Axial cube distance helper
+function distance(a, b) {
   const ax = a.q;
   const az = a.r;
   const ay = -ax - az;
@@ -9,12 +14,28 @@ function distanceAxial(a, b) {
   return Math.max(Math.abs(ax - bx), Math.abs(ay - by), Math.abs(az - bz));
 }
 
-// Simple A* pathfinder for hex axial coordinates using a uniform cost heuristic
-export function findPathHex(start, goal, neighborsFn, costFn) {
-  // neighborsFn(q,r) => list of {q,r}
-  // costFn(a,b) => numeric cost from a to b
-  const startKey = `${start.q},${start.r}`;
-  const goalKey = `${goal.q},${goal.r}`;
+// Internal axial neighbor offsets
+const OFFSETS = [
+  { q: 1, r: 0 }, { q: -1, r: 0 },
+  { q: 0, r: 1 }, { q: 0, r: -1 },
+  { q: 1, r: -1 }, { q: -1, r: 1 },
+];
+
+/**
+ * A* pathfinder operating on a WorldGrid.
+ * @param {{q:number,r:number}|{x:number,z:number}} start
+ * @param {{q:number,r:number}|{x:number,z:number}} goal
+ * @param {WorldGrid} grid
+ * @param {(a:object,b:object)=>number} [costFn]
+ * @returns {Array<{q:number,r:number}>|null}
+ */
+export function findPath(start, goal, grid, costFn) {
+  if (!grid) return null;
+  const startCell = ('q' in start && 'r' in start) ? start : grid.worldToCell(start.x, start.z);
+  const goalCell = ('q' in goal && 'r' in goal) ? goal : grid.worldToCell(goal.x, goal.z);
+
+  const startKey = `${startCell.q},${startCell.r}`;
+  const goalKey = `${goalCell.q},${goalCell.r}`;
   const open = new Map();
   const closed = new Set();
   const cameFrom = new Map();
@@ -22,51 +43,48 @@ export function findPathHex(start, goal, neighborsFn, costFn) {
   const fScore = new Map();
 
   function keyOf(p) { return `${p.q},${p.r}`; }
+  function neighbors(p) {
+    return OFFSETS.map(o => ({ q: p.q + o.q, r: p.r + o.r }));
+  }
 
   gScore.set(startKey, 0);
-  fScore.set(startKey, distanceAxial(start, goal));
-  open.set(startKey, start);
+  fScore.set(startKey, distance(startCell, goalCell));
+  open.set(startKey, startCell);
 
   while (open.size) {
-    // pick node in open with lowest fScore
     let currentKey = null;
     let currentF = Infinity;
-    for (const [k, v] of open) {
-      const f = fScore.has(k) ? fScore.get(k) : Infinity;
+    for (const [k] of open) {
+      const f = fScore.get(k) ?? Infinity;
       if (f < currentF) { currentF = f; currentKey = k; }
     }
-    if (!currentKey) break;
     const [cq, cr] = currentKey.split(',').map(Number);
     const current = { q: cq, r: cr };
-
     if (currentKey === goalKey) {
-      // reconstruct path
       const path = [];
       let k = currentKey;
       while (k) {
-        const [q,r] = k.split(',').map(Number);
+        const [q, r] = k.split(',').map(Number);
         path.unshift({ q, r });
         k = cameFrom.get(k);
       }
       return path;
     }
-
     open.delete(currentKey);
     closed.add(currentKey);
-
-    const neighs = neighborsFn(current.q, current.r) || [];
-    for (const n of neighs) {
+    for (const n of neighbors(current)) {
       const nk = keyOf(n);
       if (closed.has(nk)) continue;
-      const tentativeG = (gScore.get(currentKey) || Infinity) + (typeof costFn === 'function' ? costFn(current, n) : 1);
-      if (!open.has(nk)) open.set(nk, n);
-      else if (tentativeG >= (gScore.get(nk) || Infinity)) continue;
-      cameFrom.set(nk, currentKey);
-      gScore.set(nk, tentativeG);
-      fScore.set(nk, tentativeG + distanceAxial(n, goal));
+      const tentativeG = (gScore.get(currentKey) ?? Infinity) + (typeof costFn === 'function' ? costFn(current, n) : 1);
+      if (!open.has(nk) || tentativeG < (gScore.get(nk) ?? Infinity)) {
+        cameFrom.set(nk, currentKey);
+        gScore.set(nk, tentativeG);
+        fScore.set(nk, tentativeG + distance(n, goalCell));
+        open.set(nk, n);
+      }
     }
   }
-  return null; // no path
+  return null;
 }
 
-export default { findPathHex };
+export default { findPath };

--- a/client/src/3d2/domain/world/generator.js
+++ b/client/src/3d2/domain/world/generator.js
@@ -1,7 +1,7 @@
 import * as worldGen from './index';
 import { makeEntity } from '../entities';
 import { SeededRNG } from '../seeded';
-import { axialToXZ } from '@/3d2/config/layout';
+import { WorldGrid } from '../grid/WorldGrid';
 
 // Simple deterministic placement helper that samples generator cells inside a
 // radius and places a small set of entities (towns) at spots with high elevation
@@ -15,10 +15,11 @@ import { axialToXZ } from '@/3d2/config/layout';
 function populateEntities(seed, radius) {
   const gen = worldGen.createWorldGenerator('hex', seed);
   const rng = new SeededRNG(String(seed).split('').reduce((s,c)=>s+c.charCodeAt(0),0));
+  const grid = new WorldGrid(1);
   const entities = [];
   for (let q = -radius; q <= radius; q++) {
     for (let r = Math.max(-radius, -q - radius); r <= Math.min(radius, -q + radius); r++) {
-      const { x, z } = axialToXZ(q, r);
+      const { x, z } = grid.cellToWorld({ q, r });
       const cell = gen.getByXZ(x, z);
       // heuristic: prefer low slope, mid elevation land
   // Accept tile-shaped cell or legacy fields wrapper


### PR DESCRIPTION
## Summary
- expose `cellToWorld` and `worldToCell` conversions on WorldGrid and drop axial neighbors
- replace hex navigator with world/cell-aware A* pathfinder
- update world generator to use new grid API

## Testing
- `npm --prefix shared test -- --run`
- `npm --prefix server test`


------
https://chatgpt.com/codex/tasks/task_e_68aaa4ca901483279c64df858d7b8623