### PR TITLE
Fix worldgen FBM sampling after coord refactor

### DIFF
--- a/shared/lib/worldgen/layers/layer02_regions.js
+++ b/shared/lib/worldgen/layers/layer02_regions.js
@@ -2,6 +2,7 @@
 // Layer 2: mesoscale regions and archetype assignment (stub)
 
 import { fbm } from '../noiseUtils.js';
+import { makeSimplex } from '../noiseFactory.js';
 
 const ARCHETYPES = ['Megaplain','Badlands','HighPlateau','BrokenHighlands','Basins','InlandRidge','CoastalShelf'];
 
@@ -12,7 +13,10 @@ function pickArchetype(ctx, v) {
 
 function computeTilePart(ctx) {
   const scale = ctx.cfg.layers.layer2.regionNoiseScale || 0.02;
-  const v = fbm(ctx, ctx.x * scale, ctx.z * scale, 3);
+  // sample FBM noise in world-space using the world seed for continuity
+  const noise = makeSimplex(String(ctx.seed));
+  const sampler = fbm(noise, 3, 2.0, 0.5);
+  const v = (sampler(ctx.x * scale, ctx.z * scale) + 1) / 2; // normalize to 0..1
   const regionId = Math.abs(Math.floor((ctx.x * 31 + ctx.z * 17 + Math.floor(v * 1000))));
   const archetype = pickArchetype(ctx, v);
   return { region: { id: regionId, archetype } };

--- a/shared/lib/worldgen/layers/layer04_specials.js
+++ b/shared/lib/worldgen/layers/layer04_specials.js
@@ -2,11 +2,14 @@
 // Layer 4: special/rare regions (stub)
 
 import { fbm } from '../noiseUtils.js';
+import { makeSimplex } from '../noiseFactory.js';
 
 const SPECIALS = ['frozen_jungle','volcanic_seafloor','glass_desert','obsidian_flats','mushroom_glade'];
 
 function computeTilePart(ctx) {
-  const v = fbm(ctx, ctx.x * 0.002, ctx.z * 0.002, 2);
+  const noise = makeSimplex(String(ctx.seed));
+  const sampler = fbm(noise, 2, 2.0, 0.5);
+  const v = (sampler(ctx.x * 0.002, ctx.z * 0.002) + 1) / 2;
   // rarity threshold depends on rarityMultiplier
   const thr = 0.995 * (1 / (ctx.cfg.layers.layer4.rarityMultiplier || 1));
   if (v > thr) {


### PR DESCRIPTION
## Summary
- use simplex-based fbm samplers directly in region, biome and specials layers
- normalize fbm outputs to 0..1 before using them

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aab33a8d448327b2fe9380718ea664