### PR TITLE
fix: convert cartesian to axial before sampling

### DIFF
--- a/client/src/3d/world/generation/HexWorldGenerator.js
+++ b/client/src/3d/world/generation/HexWorldGenerator.js
@@ -61,6 +61,13 @@ function axialToPlane(q, r) {
   return { x, y };
 }
 
+// Inverse of axialToPlane for flat-top hexes
+function planeToAxial(x, y) {
+  const q = x / 1.5;
+  const r = y / SQRT3 - q / 2;
+  return { q, r };
+}
+
 // Worley (cellular) distance to closest and 2nd closest feature points in 3x3 neighborhood
 function worley2F12(x, y, cellSize, seed) {
   const cx = Math.floor(x / cellSize);
@@ -557,12 +564,17 @@ export function createHexGenerator(seed) {
     };
   }
 
+  function getByXZ(x, z) {
+    const { q, r } = planeToAxial(x, z);
+    return get(q, r);
+  }
+
   function setTuning(newTuning = {}) {
     tuning = { ...tuning, ...newTuning };
     applyTuning();
   }
 
-  return { get, setTuning };
+  return { get, getByXZ, setTuning };
 }
 
 export function computeHex(seed, q, r) {


### PR DESCRIPTION
## Summary
- handle cartesian world coords by converting to axial before sampling
- expose `getByXZ` for sampling hex data by world x/z

## Testing
- `npm --prefix shared run test -- --run`
- `npm --prefix server run test`
- `node --input-type=module - <<'NODE'
import {createHexGenerator} from './client/src/3d/world/generation/HexWorldGenerator.js';
const gen = createHexGenerator(123);
const sample = [
  {x:0,z:0},
  {x:30,z:10},
  {x:150,z:-20}
];
for(const s of sample){
  const good = gen.getByXZ(s.x, s.z).elevationBand;
  const bad = gen.get(s.x, s.z).elevationBand; // interpreting as axial
  console.log(`${s.x},${s.z}: good=${good}, bad=${bad}`);
}
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68aac56d41808327a0453810121d4ae1