### PR TITLE
Preserve world-space coordinates for noise sampling

### DIFF
--- a/client/src/3d2/domain/world/localGenerator.js
+++ b/client/src/3d2/domain/world/localGenerator.js
@@ -1,5 +1,5 @@
 import * as shared from '../../../../../shared/lib/worldgen/index.js';
-import { worldXZToAxial, roundAxial } from '../../config/layout.js';
+import { worldXZToAxial, roundAxial, axialToXZ } from '../../config/layout.js';
 
 // Minimal adapter: return the shared Tile object directly. Consumers should
 // use the tile shape (tile.elevation, tile.height, tile.palette, etc.).
@@ -9,13 +9,17 @@ export function createWorldGenerator(type = 'hex', seed = 'seed', opts = {}) {
   let cfg = opts || {};
   return {
     // Deprecated: prefer getByXZ(x,z)
-    get(q, r) {
-      return shared.generateTile(seed, q, r, cfg);
+    get(q, r, x, z) {
+      if (typeof x !== 'number' || typeof z !== 'number') {
+        const coords = axialToXZ(q, r, { layoutRadius: 1, spacingFactor: 1 });
+        x = coords.x; z = coords.z;
+      }
+      return shared.generateTile(seed, q, r, x, z, cfg);
     },
     getByXZ(x, z) {
       const frac = worldXZToAxial(x, z, { layoutRadius: 1, spacingFactor: 1 });
       const { q, r } = roundAxial(frac.q, frac.r);
-      return this.get(q, r);
+      return this.get(q, r, x, z);
     },
     setTuning(newOpts = {}) {
       cfg = Object.assign({}, cfg, newOpts);

--- a/shared/lib/worldgen/README.md
+++ b/shared/lib/worldgen/README.md
@@ -4,7 +4,7 @@ Purpose
 - Provide a deterministic, dependency-light API for generating tile data used by both server and client.
 
 API
-- generateTile(seed, q, r, cfgPartial) -> Tile object
+- generateTile(seed, q, r, [x, z,] cfgPartial) -> Tile object
 - getDefaultConfig() -> default config
 
 Tile shape (partial)

--- a/shared/lib/worldgen/index.js
+++ b/shared/lib/worldgen/index.js
@@ -31,9 +31,15 @@ function normalizeConfig(partial) {
   return base;
 }
 
-function generateTile(seed, q, r, cfgPartial) {
+function generateTile(seed, q, r, xOrCfg, zOrCfg, cfgMaybe) {
+  let x; let z; let cfgPartial;
+  if (typeof xOrCfg === 'number' && typeof zOrCfg === 'number') {
+    x = xOrCfg; z = zOrCfg; cfgPartial = cfgMaybe;
+  } else {
+    cfgPartial = xOrCfg;
+    ({ x, z } = axialToXZ(q, r, { layoutRadius: 1, spacingFactor: 1 }));
+  }
   const cfg = normalizeConfig(cfgPartial);
-  const { x, z } = axialToXZ(q, r, { layoutRadius: 1, spacingFactor: 1 });
   const ctx = { seed: String(seed), q, r, x, z, cfg, rng: createRng(seed, x, z), noise };
 
   // run layers in order; parts are partial tile outputs consumed by later layers

--- a/shared/lib/worldgen/layers/layer01_continents.js
+++ b/shared/lib/worldgen/layers/layer01_continents.js
@@ -77,10 +77,9 @@ function computeTilePart(ctx) {
   const macroOctaves = Math.max(1, (fbmCfg.octaves ? Math.max(1, Math.floor(fbmCfg.octaves)) : 1));
   const macroSampler = fbmFactory(noise, macroOctaves, fbmCfg.lacunarity || 1.8, fbmCfg.gain || 0.3);
 
-  // Sample in world-space (flat-top axial->XZ) so wavelengths map to true hex spacing.
-  const sqrt3 = Math.sqrt(3);
-  const worldX = 1.5 * q;
-  const worldZ = sqrt3 * (r + q / 2);
+  // Sample in world-space so wavelengths map to true hex spacing.
+  const worldX = ctx.x;
+  const worldZ = ctx.z;
   const sx = worldX / plateSize;
   const sy = worldZ / plateSize;
   // Avoid domain warp for the macro pass (it injects high-frequency energy)


### PR DESCRIPTION
## Summary
- pass x/z through world generation and avoid re-deriving them from snapped q/r
- sample layer01 continents noise using world-space positions
- document optional x/z parameters in shared worldgen API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aacdbfeba8832788e9bcf534ee7c11