### PR TITLE
Refactor continental mask to use x/z coordinates

### DIFF
--- a/client/src/3d2/domain/world/continents.js
+++ b/client/src/3d2/domain/world/continents.js
@@ -3,12 +3,12 @@ import worldConfig from './worldConfig.json';
 
 // Build a continental mask: low-frequency FBM warped to produce large landmasses.
 // Returns normalized height 0..1 where values below seaLevel map into ocean bands.
-export function continentalMask(noise, q, r, scale = 48) {
-  const x = q / scale;
-  const y = r / scale;
+export function continentalMask(noise, x, z, scale) {
+  const sx = x / scale;
+  const sz = z / scale;
 
   const warpCfg = worldConfig.domainWarp || {};
-  const warped = domainWarp(noise, x, y, warpCfg);
+  const warped = domainWarp(noise, sx, sz, warpCfg);
 
   // Use one fewer octave for macro geography to keep it very smooth.
   const fbmCfg = worldConfig.fbm || { octaves: 5, lacunarity: 2.0, gain: 0.5 };

--- a/client/src/3d2/domain/world/localGenerator.old.js
+++ b/client/src/3d2/domain/world/localGenerator.old.js
@@ -30,12 +30,14 @@ function createHexGenerator(seed, opts = {}) {
 
   function heightAt(q, r) {
     // Macro continental mask (smooth, large scale)
-    const macro = continentalMask(noise, q, r, worldConfig.plateCellSize || 48);
+    const x = q;
+    const z = r;
+    const macro = continentalMask(noise, x, z, worldConfig.plateCellSize || 48);
 
     // Mesoscale detail: sample at tile scale using FBM & warp
-    const x = q / scale;
-    const y = r / scale;
-    const w = domainWarp(noise, x, y, warpCfg);
+    const nx = q / scale;
+    const ny = r / scale;
+    const w = domainWarp(noise, nx, ny, warpCfg);
     const v = fbmSampler(w.x, w.y); // -1..1
     const detail = (v + 1) / 2;
 


### PR DESCRIPTION
## Summary
- refactor `continentalMask` to accept cartesian `x,z` coordinates instead of axial `q,r`
- update legacy generator to call the refactored mask with `x,z` and adjust local variables

## Testing
- `npm test`
- `npm --prefix server run test`
- `npm --prefix client run test:3d2` *(fails: Could not resolve "/workspace/daemios/client/vitest.config.ts")*
- `npm --prefix client run lint` *(fails: 189 problems (56 errors, 133 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68aae0ee2d748327911edaf8ad71ce83