### PR TITLE
refactor(worldgen): decouple from client axial conversion

### DIFF
--- a/client/src/3d2/domain/world/adapters/sharedWorldgen.js
+++ b/client/src/3d2/domain/world/adapters/sharedWorldgen.js
@@ -3,8 +3,8 @@
 
 import * as shared from '../../../../../shared/lib/worldgen/index.js';
 
-export function generateTile(seed, q, r, cfg) {
-  return shared.generateTile(seed, q, r, cfg);
+export function generateTile(seed, coords, cfg) {
+  return shared.generateTile(seed, coords, cfg);
 }
 
 export function getDefaultConfig() {

--- a/client/src/3d2/domain/world/localGenerator.js
+++ b/client/src/3d2/domain/world/localGenerator.js
@@ -9,7 +9,7 @@ export function createWorldGenerator(type = 'hex', seed = 'seed', opts = {}) {
   let cfg = opts || {};
   return {
     getByXZ(x, z, q, r) {
-      return shared.generateTile(seed, q, r, x, z, cfg);
+      return shared.generateTile(seed, { q, r, x, z }, cfg);
     },
     // Helper for hex callers: derive world {x,z} from {q,r}
     getByQR(q, r) {

--- a/shared/lib/worldgen/README.md
+++ b/shared/lib/worldgen/README.md
@@ -4,7 +4,7 @@ Purpose
 - Provide a deterministic, dependency-light API for generating tile data used by both server and client.
 
 API
-- generateTile(seed, q, r, [x, z,] cfgPartial) -> Tile object
+- generateTile(seed, { q, r, x, z }, cfgPartial) -> Tile object (q/r optional)
 - getDefaultConfig() -> default config
 
 Tile shape (partial)

--- a/shared/scripts/sampleLayer1.js
+++ b/shared/scripts/sampleLayer1.js
@@ -4,7 +4,7 @@ function sample(seed, qStart, qEnd, rStart, rEnd, cfgPartial) {
   for (let q = qStart; q <= qEnd; q++) {
     let row = [];
     for (let r = rStart; r <= rEnd; r++) {
-      const tile = generateTile(seed, q, r, cfgPartial);
+      const tile = generateTile(seed, { q, r }, cfgPartial);
       row.push(Number((tile.height ?? (tile.elevation && tile.elevation.normalized) ?? 0).toFixed(3)));
     }
     console.log(`q=${q}:`, row.join(' '));

--- a/shared/test/worldgen.test.js
+++ b/shared/test/worldgen.test.js
@@ -7,8 +7,8 @@ const g = await import(path.join(__dirname, '..', 'lib', 'worldgen', 'index.js')
 
 describe('shared worldgen', () => {
   it('generates deterministic tile for fixed seed and coords', () => {
-    const a = g.generateTile('seed-test', 1, 2);
-    const b = g.generateTile('seed-test', 1, 2);
+    const a = g.generateTile('seed-test', { q: 1, r: 2 });
+    const b = g.generateTile('seed-test', { q: 1, r: 2 });
     expect(a).toBeDefined();
     expect(a.q).toBe(1);
     expect(a.r).toBe(2);


### PR DESCRIPTION
## Summary
- drop client axialToXZ import and add local hex axial->Cartesian helper
- allow generateTile to accept `{q,r,x,z}` coords with optional axial data
- update adapters, tests, and docs for new generateTile signature

## Testing
- `npm --prefix shared test -- --run`
- `npm --prefix server test`


------
https://chatgpt.com/codex/tasks/task_e_68aae3d627548327918dc65d1ffaad75