### PR TITLE
Refactor grid interface to {x,z} and add square grid

### DIFF
--- a/client/src/3d2/domain/grid/SquareGrid.js
+++ b/client/src/3d2/domain/grid/SquareGrid.js
@@ -1,0 +1,51 @@
+// Minimal SquareGrid implementation sharing the WorldGrid interface.
+// Uses direct Cartesian math for cell/world conversions.
+
+export class SquareGrid {
+  /**
+   * @param {number} scale visual/world size of a cell (default 1)
+   */
+  constructor(scale = 1) {
+    this.scale = typeof scale === 'number' ? scale : 1;
+  }
+
+  _cellSize() {
+    return this.scale;
+  }
+
+  // Convert cell coordinates {x,z} or packed index to world x,z
+  cellToWorld(idx) {
+    const { x, z } = typeof idx === 'object' ? this._normalizeCell(idx) : this._fromIndex(idx);
+    const size = this._cellSize();
+    return { x: x * size, z: z * size };
+  }
+
+  // Convert world x,z to cell coordinates {x,z}
+  worldToCell(x, z) {
+    const size = this._cellSize();
+    return { x: Math.round(x / size), z: Math.round(z / size) };
+  }
+
+  // Chebyshev distance (4 or 8-neighbor compatible)
+  distance(a, b) {
+    const ax = a.x, az = a.z;
+    const bx = b.x, bz = b.z;
+    return Math.max(Math.abs(ax - bx), Math.abs(az - bz));
+  }
+
+  _fromIndex(i) {
+    if (typeof i === 'string') {
+      const [x, z] = i.split(',').map(Number);
+      return { x, z };
+    }
+    const x = (i >> 16) | 0;
+    const z = (i & 0xffff) << 16 >> 16;
+    return { x, z };
+  }
+
+  _normalizeCell(obj) {
+    return { x: obj.x ?? 0, z: obj.z ?? 0 };
+  }
+}
+
+export default SquareGrid;

--- a/client/src/3d2/domain/nav/HexNav.js
+++ b/client/src/3d2/domain/nav/HexNav.js
@@ -3,48 +3,48 @@
 
 import { WorldGrid } from '../grid/WorldGrid';
 
-// Axial cube distance helper
+// Axial cube distance helper using common {x,z} cell coords
 function distance(a, b) {
-  const ax = a.q;
-  const az = a.r;
+  const ax = a.x;
+  const az = a.z;
   const ay = -ax - az;
-  const bx = b.q;
-  const bz = b.r;
+  const bx = b.x;
+  const bz = b.z;
   const by = -bx - bz;
   return Math.max(Math.abs(ax - bx), Math.abs(ay - by), Math.abs(az - bz));
 }
 
-// Internal axial neighbor offsets
+// Internal axial neighbor offsets expressed with {x,z}
 const OFFSETS = [
-  { q: 1, r: 0 }, { q: -1, r: 0 },
-  { q: 0, r: 1 }, { q: 0, r: -1 },
-  { q: 1, r: -1 }, { q: -1, r: 1 },
+  { x: 1, z: 0 }, { x: -1, z: 0 },
+  { x: 0, z: 1 }, { x: 0, z: -1 },
+  { x: 1, z: -1 }, { x: -1, z: 1 },
 ];
 
 /**
  * A* pathfinder operating on a WorldGrid.
- * @param {{q:number,r:number}|{x:number,z:number}} start
- * @param {{q:number,r:number}|{x:number,z:number}} goal
+ * @param {{x:number,z:number}} start start cell coordinates
+ * @param {{x:number,z:number}} goal goal cell coordinates
  * @param {WorldGrid} grid
  * @param {(a:object,b:object)=>number} [costFn]
- * @returns {Array<{q:number,r:number}>|null}
+ * @returns {Array<{x:number,z:number}>|null}
  */
 export function findPath(start, goal, grid, costFn) {
   if (!grid) return null;
-  const startCell = ('q' in start && 'r' in start) ? start : grid.worldToCell(start.x, start.z);
-  const goalCell = ('q' in goal && 'r' in goal) ? goal : grid.worldToCell(goal.x, goal.z);
+  const startCell = start;
+  const goalCell = goal;
 
-  const startKey = `${startCell.q},${startCell.r}`;
-  const goalKey = `${goalCell.q},${goalCell.r}`;
+  const startKey = `${startCell.x},${startCell.z}`;
+  const goalKey = `${goalCell.x},${goalCell.z}`;
   const open = new Map();
   const closed = new Set();
   const cameFrom = new Map();
   const gScore = new Map();
   const fScore = new Map();
 
-  function keyOf(p) { return `${p.q},${p.r}`; }
+  function keyOf(p) { return `${p.x},${p.z}`; }
   function neighbors(p) {
-    return OFFSETS.map(o => ({ q: p.q + o.q, r: p.r + o.r }));
+    return OFFSETS.map(o => ({ x: p.x + o.x, z: p.z + o.z }));
   }
 
   gScore.set(startKey, 0);
@@ -58,14 +58,14 @@ export function findPath(start, goal, grid, costFn) {
       const f = fScore.get(k) ?? Infinity;
       if (f < currentF) { currentF = f; currentKey = k; }
     }
-    const [cq, cr] = currentKey.split(',').map(Number);
-    const current = { q: cq, r: cr };
+    const [cx, cz] = currentKey.split(',').map(Number);
+    const current = { x: cx, z: cz };
     if (currentKey === goalKey) {
       const path = [];
       let k = currentKey;
       while (k) {
-        const [q, r] = k.split(',').map(Number);
-        path.unshift({ q, r });
+        const [x, z] = k.split(',').map(Number);
+        path.unshift({ x, z });
         k = cameFrom.get(k);
       }
       return path;

--- a/client/src/3d2/domain/nav/SquareNav.js
+++ b/client/src/3d2/domain/nav/SquareNav.js
@@ -1,12 +1,12 @@
 // Minimal square-grid nav placeholder (keeps API parity)
 export function findPathSquare(start, goal, neighborsFn, costFn) {
   // naive BFS for demo purposes
-  const startKey = `${start.x},${start.y}`;
-  const goalKey = `${goal.x},${goal.y}`;
+  const startKey = `${start.x},${start.z}`;
+  const goalKey = `${goal.x},${goal.z}`;
   const queue = [start];
   const cameFrom = new Map();
   const visited = new Set([startKey]);
-  function keyOf(p){ return `${p.x},${p.y}`; }
+  function keyOf(p){ return `${p.x},${p.z}`; }
   while (queue.length) {
     const cur = queue.shift();
     const ck = keyOf(cur);
@@ -14,13 +14,13 @@ export function findPathSquare(start, goal, neighborsFn, costFn) {
       const path = [];
       let k = ck;
       while (k) {
-        const [x,y] = k.split(',').map(Number);
-        path.unshift({ x, y });
+        const [x,z] = k.split(',').map(Number);
+        path.unshift({ x, z });
         k = cameFrom.get(k);
       }
       return path;
     }
-    const neighs = neighborsFn(cur.x, cur.y) || [];
+    const neighs = neighborsFn(cur.x, cur.z) || [];
     for (const n of neighs) {
       const nk = keyOf(n);
       if (visited.has(nk)) continue;

--- a/client/src/3d2/domain/world/generator.js
+++ b/client/src/3d2/domain/world/generator.js
@@ -19,7 +19,7 @@ function populateEntities(seed, radius) {
   const entities = [];
   for (let q = -radius; q <= radius; q++) {
     for (let r = Math.max(-radius, -q - radius); r <= Math.min(radius, -q + radius); r++) {
-      const { x, z } = grid.cellToWorld({ q, r });
+        const { x, z } = grid.cellToWorld({ x: q, z: r });
       const cell = gen.getByXZ(x, z);
       // heuristic: prefer low slope, mid elevation land
   // Accept tile-shaped cell or legacy fields wrapper

--- a/client/src/3d2/scenes/WorldMapScene.js
+++ b/client/src/3d2/scenes/WorldMapScene.js
@@ -116,7 +116,7 @@ export class WorldMapScene {
   try { this._clutter.prepareFromGrid(this.grid); } catch (e) { console.debug('WorldMapScene: clutter.prepareFromGrid failed', e); }
       try {
         // commit an initial region matching the grid radius
-  this._clutter.commitInstances({ layoutRadius: this._layoutRadius || 1, contactScale: 0.6, hexMaxY: 1, modelScaleY: () => 1, axialRect: { qMin: -this._gridRadius, qMax: this._gridRadius, rMin: -this._gridRadius, rMax: this._gridRadius } });
+    this._clutter.commitInstances({ layoutRadius: this._layoutRadius || 1, contactScale: 0.6, hexMaxY: 1, modelScaleY: () => 1, cellRect: { xMin: -this._gridRadius, xMax: this._gridRadius, zMin: -this._gridRadius, zMax: this._gridRadius } });
       } catch (e) {
         console.debug('WorldMapScene: clutter.commitInstances failed', e);
       }
@@ -475,7 +475,7 @@ export class WorldMapScene {
     try {
       if (this._clutter) {
         try { this._clutter.prepareFromGrid(this.grid); } catch (e) { console.debug('WorldMapScene: clutter.prepareFromGrid failed (setGridRadius)', e); }
-        // if chunkManager exists compute axialRect based on chunk extents
+        // if chunkManager exists compute cellRect based on chunk extents
         if (this.chunkManager) {
           const cols = this.chunkManager.chunkCols || 8;
           const rows = this.chunkManager.chunkRows || 8;
@@ -483,14 +483,14 @@ export class WorldMapScene {
           const cx = this.chunkManager.centerChunk ? this.chunkManager.centerChunk.x : 0;
           const cy = this.chunkManager.centerChunk ? this.chunkManager.centerChunk.y : 0;
           const rect = {
-            qMin: (cx - nr) * cols,
-            qMax: (cx + nr) * cols + (cols - 1),
-            rMin: (cy - nr) * rows,
-            rMax: (cy + nr) * rows + (rows - 1),
+            xMin: (cx - nr) * cols,
+            xMax: (cx + nr) * cols + (cols - 1),
+            zMin: (cy - nr) * rows,
+            zMax: (cy + nr) * rows + (rows - 1),
           };
-          this._clutter.commitInstances({ layoutRadius: this._layoutRadius || 1, contactScale: 0.6, hexMaxY: 1, modelScaleY: () => 1, axialRect: rect });
+          this._clutter.commitInstances({ layoutRadius: this._layoutRadius || 1, contactScale: 0.6, hexMaxY: 1, modelScaleY: () => 1, cellRect: rect });
         } else {
-          this._clutter.commitInstances({ layoutRadius: this._layoutRadius || 1, contactScale: 0.6, hexMaxY: 1, modelScaleY: () => 1, axialRect: { qMin: -radius, qMax: radius, rMin: -radius, rMax: radius } });
+          this._clutter.commitInstances({ layoutRadius: this._layoutRadius || 1, contactScale: 0.6, hexMaxY: 1, modelScaleY: () => 1, cellRect: { xMin: -radius, xMax: radius, zMin: -radius, zMax: radius } });
         }
       }
     } catch (e) {


### PR DESCRIPTION
## Summary
- refactor WorldGrid to expose cell/world conversions via {x,z}
- add SquareGrid with direct Cartesian math
- update navigation and clutter systems to use new grid interface

## Testing
- `npm --prefix shared run test -- --run`
- `npm --prefix server run test`


------
https://chatgpt.com/codex/tasks/task_e_68aaee60cff4832796fef6f8801fd5d7