### PR TITLE
Fix even-q axial conversion for negative columns

### DIFF
--- a/client/src/3d/renderer/ChunkNeighborhood.js
+++ b/client/src/3d/renderer/ChunkNeighborhood.js
@@ -320,7 +320,7 @@ export default class ChunkNeighborhood {
         const gCol = baseCol + col;
         const gRow = baseRow + row;
         const q = gCol; // even-q offset -> axial
-        const r = gRow - Math.floor(gCol / 2);
+        const r = gRow - Math.floor((gCol + (gCol & 1)) / 2);
         const x = hexWidth * q;
         const z = hexHeight * (r + q / 2);
         // Sampled timing: cell fetch

--- a/shared/test/evenq-negative-columns.test.js
+++ b/shared/test/evenq-negative-columns.test.js
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+
+function evenQToAxial(gCol, gRow) {
+  const q = gCol;
+  const r = gRow - Math.floor((gCol + (gCol & 1)) / 2);
+  return { q, r };
+}
+
+function oldFormula(gCol, gRow) {
+  return gRow - Math.floor(gCol / 2);
+}
+
+describe('even-q offset to axial conversion', () => {
+  it('handles negative column values', () => {
+    expect(evenQToAxial(-2, 0)).toEqual({ q: -2, r: 1 });
+    expect(evenQToAxial(-1, 0)).toEqual({ q: -1, r: 0 });
+    expect(evenQToAxial(-1, 5)).toEqual({ q: -1, r: 5 });
+    expect(evenQToAxial(-3, 4)).toEqual({ q: -3, r: 5 });
+  });
+
+  it('differs from old formula for negative columns', () => {
+    const newR = evenQToAxial(-1, 0).r;
+    const oldR = oldFormula(-1, 0);
+    expect(newR).not.toBe(oldR);
+  });
+});


### PR DESCRIPTION
## Summary
- correct axial row calculation in ChunkNeighborhood to use even-q formula
- add tests to ensure negative columns are handled and highlight difference from old conversion

## Testing
- `npx --prefix client eslint client/src/3d/renderer/ChunkNeighborhood.js` *(fails: Empty block statements and unused vars)*
- `npm --prefix shared run test -- --run`
- `npm --prefix server run test`
- `npm --prefix client run build` *(fails: Rollup could not resolve @shared/utils/cartesian)*

------
https://chatgpt.com/codex/tasks/task_e_68ab708da3888327b9d4586a8ccc30ba