### PR TITLE
refactor: use simplex-noise import

### DIFF
--- a/shared/lib/worldgen/noiseFactory.js
+++ b/shared/lib/worldgen/noiseFactory.js
@@ -1,19 +1,5 @@
 import { SeededRNG } from './rng.js';
-
-// Avoid importing Node-only 'module' at top-level (Vite/browser will externalize it).
-// Instead, attempt a guarded runtime require when running under Node. In browser
-// builds this will not run and we fall back to a deterministic JS stub.
-let createNoise2D = null;
-try {
-  // `require` may be available in the Node test/runtime environment. Guard so
-  // bundlers targeting the browser don't attempt to resolve it.
-  if (typeof process !== 'undefined' && process.versions && process.versions.node && typeof require === 'function') {
-    const simplex = require('simplex-noise');
-    createNoise2D = simplex && (simplex.createNoise2D || (simplex.default && simplex.default.createNoise2D));
-  }
-} catch (e) {
-  createNoise2D = null;
-}
+import { createNoise2D } from 'simplex-noise';
 
 // Create a seeded noise2D function per tile using our SeededRNG as the
 // random source. We return an object with noise2D(x,y) to match the
@@ -24,17 +10,6 @@ export function makeSimplex(seed, x, z) {
   for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) >>> 0;
   const lcg = new SeededRNG(h);
   const rngFunc = () => lcg.next();
-
-  if (typeof createNoise2D === 'function') {
-    const fn = createNoise2D(rngFunc);
-    return { noise2D: fn };
-  }
-
-  // Fallback deterministic stub if package shape is unexpected
-  return {
-    noise2D(x, y) {
-      const v = Math.sin(x * 12.9898 + y * 78.233 + lcg.next() * 43758.5453);
-      return (v - Math.floor(v)) * 2 - 1;
-    }
-  };
+  const fn = createNoise2D(rngFunc);
+  return { noise2D: fn };
 }

--- a/shared/package-lock.json
+++ b/shared/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "daemios-shared",
       "version": "0.1.0",
+      "dependencies": {
+        "simplex-noise": "^4.0.3"
+      },
       "devDependencies": {
         "vitest": "^3.2.4"
       }
@@ -1135,6 +1138,12 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true
     },
+    "node_modules/simplex-noise": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/simplex-noise/-/simplex-noise-4.0.3.tgz",
+      "integrity": "sha512-qSE2I4AngLQG7BXqoZj51jokT4WUXe8mOBrvfOXpci8+6Yu44+/dD5zqDpOx3Ux792eamTd2lLcI8jqFntk/lg==",
+      "license": "MIT"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2051,6 +2060,11 @@
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true
+    },
+    "simplex-noise": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/simplex-noise/-/simplex-noise-4.0.3.tgz",
+      "integrity": "sha512-qSE2I4AngLQG7BXqoZj51jokT4WUXe8mOBrvfOXpci8+6Yu44+/dD5zqDpOx3Ux792eamTd2lLcI8jqFntk/lg=="
     },
     "source-map-js": {
       "version": "1.2.1",

--- a/shared/package.json
+++ b/shared/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "test": "vitest"
   },
+  "dependencies": {
+    "simplex-noise": "^4.0.3"
+  },
   "devDependencies": {
     "vitest": "^3.2.4"
   }


### PR DESCRIPTION
## Summary
- replace guarded require with explicit `simplex-noise` import
- remove Math.sin noise stub so worldgen always uses simplex noise
- declare `simplex-noise` dependency for shared package

## Testing
- `npm --prefix shared test -- --run`
- `npm --prefix server test -- --run`
- `node -e "import { makeSimplex } from './shared/lib/worldgen/noiseFactory.js'; const n=makeSimplex('seed',0,0).noise2D; for(let y=0;y<5;y++){let row=[];for(let x=0;x<5;x++){row.push(n(x/5,y/5).toFixed(3));} console.log(row.join(' '));}"`


------
https://chatgpt.com/codex/tasks/task_e_68ab7d78f1bc8327832b812c7d83257d