### PR TITLE
Fix water alignment by removing legacy hex spacing

### DIFF
--- a/client/src/3d2/renderer/ChunkManager.js
+++ b/client/src/3d2/renderer/ChunkManager.js
@@ -16,7 +16,7 @@ export default class ChunkManager {
     this.scene = opts.scene;
     this.world = opts.world;
     this.layoutRadius = opts.layoutRadius || 1;
-    this.spacingFactor = opts.spacingFactor || 0.85;
+    this.spacingFactor = (typeof opts.spacingFactor === 'number') ? opts.spacingFactor : 1;
     this.modelScaleFactor = opts.modelScaleFactor || 1;
   // native geometry max Y (in model units) after any loader normalization
   this.hexMaxYNative = typeof opts.hexMaxY === 'number' ? opts.hexMaxY : 1.0;

--- a/client/src/3d2/scenes/WorldMapScene.js
+++ b/client/src/3d2/scenes/WorldMapScene.js
@@ -170,7 +170,7 @@ export class WorldMapScene {
           scene: this.scene,
           generator: this._generator,
           layoutRadius: this._layoutRadius,
-          spacingFactor: (this._hexModel && this._hexModel.contactScale) ? this._hexModel.contactScale : 1,
+          spacingFactor: 1,
           neighborRadius: this._gridRadius,
           pastelColorForChunk,
           // Prevent double-scaling: use layoutRadius for X/Z footprint and


### PR DESCRIPTION
## Summary
- use a neutral spacing factor in the chunk manager so axial-to-world math reflects the model's native size
- always construct the world map chunk manager with spacingFactor=1 so instanced terrain and water shaders share the same scale

## Testing
- `npm --prefix client run lint` *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c8fbe2460c83279f16dbfc5885dae2