### PR TITLE
Adjust water builder hex layout mapping

### DIFF
--- a/client/src/3d2/scenes/WorldMapScene.js
+++ b/client/src/3d2/scenes/WorldMapScene.js
@@ -266,8 +266,9 @@ export class WorldMapScene {
               } catch (e) { /* ignore */ }
             },
           },
-          layoutRadius: this._layoutRadius || 1,
-          spacingFactor: cm.spacingFactor || 1,
+          layoutRadius: (cm && typeof cm.layoutRadius === 'number') ? cm.layoutRadius : (this._layoutRadius || 1),
+          spacingFactor: (cm && typeof cm.spacingFactor === 'number') ? cm.spacingFactor : 1,
+          modelScaleFactor: (cm && typeof cm.modelScaleFactor === 'number') ? cm.modelScaleFactor : 1,
           chunkCols: cm.chunkCols || 8,
           chunkRows: cm.chunkRows || 8,
           centerChunk: cm.centerChunk || { x: 0, y: 0 },


### PR DESCRIPTION
## Summary
- forward the chunk manager layout/model scaling data into the water builder
- reuse the shared axial coordinate helpers to derive water plane extents and shader parameters
- compute water plane bounds directly from axial coordinates to keep terrain and water transforms in sync

## Testing
- `npm --prefix client run lint` *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c90f87655883278ad3afc6e53c94dd