### PR TITLE
Align water plane bounds with hex layout

### DIFF
--- a/client/src/3d2/scenes/WorldMapScene.js
+++ b/client/src/3d2/scenes/WorldMapScene.js
@@ -8,7 +8,7 @@ import { createWorldGenerator } from '@/3d2/domain/world';
 import { biomeFromCell } from '@/3d2/domain/world/biomes';
 import { DEFAULT_CONFIG } from '../../../../shared/lib/worldgen/config.js';
 import { axialToXZ, XZToAxial } from '@/3d2/renderer/coordinates';
-import { BASE_HEX_SIZE } from '@/3d2/config/layout';
+import { BASE_HEX_SIZE, getHexSize } from '@/3d2/config/layout';
 import { EntityPicker } from '@/3d2/interaction/EntityPicker';
 import { createOrbitControls } from '@/3d2/interaction/orbitControls';
 import ClutterManager from '@/3d2/world/ClutterManager';
@@ -374,6 +374,15 @@ export class WorldMapScene {
           if (desiredWidth == null && typeof nb.half === 'number') {
             const side = nb.half * 2;
             desiredWidth = side; desiredDepth = side; desiredCenterX = nb.centerX || 0; desiredCenterZ = nb.centerZ || 0;
+          }
+          if (typeof desiredWidth === 'number' && typeof desiredDepth === 'number') {
+            const layoutRadiusForBounds = this._layoutRadius || 1;
+            const spacingForBounds = cm.spacingFactor || 1;
+            const hexSizeForBounds = getHexSize({ layoutRadius: layoutRadiusForBounds, spacingFactor: spacingForBounds });
+            const expandX = hexSizeForBounds;
+            const expandZ = hexSizeForBounds * Math.sqrt(3) * 0.5;
+            desiredWidth = Math.max(0.1, desiredWidth + expandX * 2);
+            desiredDepth = Math.max(0.1, desiredDepth + expandZ * 2);
           }
         }
         if (desiredWidth != null && mesh) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8484,6 +8484,9 @@
     "shared": {
       "name": "daemios-shared",
       "version": "0.1.0",
+      "dependencies": {
+        "simplex-noise": "^4.0.3"
+      },
       "devDependencies": {
         "vitest": "^3.2.4"
       }
@@ -10738,7 +10741,7 @@
         "daemios-api": "file:server",
         "daemios-shared": "file:shared",
         "daemios-web-client": "file:client",
-        "simplex-noise": "*"
+        "simplex-noise": "^4.0.3"
       },
       "dependencies": {
         "@babel/helper-string-parser": {
@@ -12700,6 +12703,7 @@
         "daemios-shared": {
           "version": "file:shared",
           "requires": {
+            "simplex-noise": "^4.0.3",
             "vitest": "^3.2.4"
           },
           "dependencies": {
@@ -16785,6 +16789,7 @@
     "daemios-shared": {
       "version": "file:shared",
       "requires": {
+        "simplex-noise": "^4.0.3",
         "vitest": "^3.2.4"
       },
       "dependencies": {


### PR DESCRIPTION
## Summary
- derive water plane bounds from axial coordinates and expand them by the hex radius so the shader domain matches world space
- expand the chunk manager sizing pass with the same hex offsets to keep runtime resizing in sync
- update layout imports and workspace lockfile metadata to reflect the shared dependency version

## Testing
- `npm --prefix client run test:3d2` *(fails: vitest config file is missing in the repo)*

------
https://chatgpt.com/codex/tasks/task_e_68c90f87655883278ad3afc6e53c94dd