### PR TITLE
Align water shader scaling with layout hex size

### DIFF
--- a/client/src/3d2/scenes/WorldMapScene.js
+++ b/client/src/3d2/scenes/WorldMapScene.js
@@ -325,7 +325,13 @@ export class WorldMapScene {
       } else {
         // fallback to naive material so scene still renders when build fails
         mat = createRealisticWaterMaterial();
-        try { if (mat && mat.uniforms) { if (typeof mat.uniforms.uTime !== 'undefined') mat.uniforms.uTime.value = 0; if (typeof mat.uniforms.uHexW !== 'undefined') mat.uniforms.uHexW.value = mat.uniforms.uHexW.value || 1.0; if (typeof mat.uniforms.uHexH !== 'undefined') mat.uniforms.uHexH.value = mat.uniforms.uHexH.value || 1.0; } mat.needsUpdate = true; } catch (e) { /* ignore */ }
+        try {
+          if (mat && mat.uniforms) {
+            if (typeof mat.uniforms.uTime !== 'undefined') mat.uniforms.uTime.value = 0;
+            if (typeof mat.uniforms.uHexSize !== 'undefined') mat.uniforms.uHexSize.value = mat.uniforms.uHexSize.value || 1.0;
+          }
+          mat.needsUpdate = true;
+        } catch (e) { /* ignore */ }
         // compute authoritative sea level (same as previous logic)
         const cfgMaxH = (DEFAULT_CONFIG && typeof DEFAULT_CONFIG.maxHeight === 'number') ? DEFAULT_CONFIG.maxHeight : 1000;
         const cfgScale = (DEFAULT_CONFIG && typeof DEFAULT_CONFIG.scale === 'number') ? DEFAULT_CONFIG.scale : 1.0;

--- a/client/src/services/water/waterBuilder.js
+++ b/client/src/services/water/waterBuilder.js
@@ -34,9 +34,11 @@ export function buildWater(ctx) {
     typeof modelScaleFactor === "number" && Number.isFinite(modelScaleFactor) && modelScaleFactor > 0
       ? modelScaleFactor
       : 1;
+  // World-space hex radius derived from centralized layout helpers.
+  const hexSizeWorld = baseHexSize * scaleXZ;
   // Hex footprint in world units (center-to-center distance along axial basis)
-  const hexW_est = baseHexSize * scaleXZ * 1.5;
-  const hexH_est = baseHexSize * scaleXZ * Math.sqrt(3);
+  const hexW_est = hexSizeWorld * 1.5;
+  const hexH_est = hexSizeWorld * Math.sqrt(3);
 
   const axialToWorld = (q, r) => {
     const pos = axialToXZ(q, r, layoutOpts);
@@ -468,6 +470,7 @@ export function buildWater(ctx) {
       distanceTexture: distTex,
       coverageTexture: coverageTex,
       seabedTexture: seabedTex,
+      hexSize: hexSizeWorld,
       hexW: hexW_est,
       hexH: hexH_est,
   gridW,
@@ -485,6 +488,7 @@ export function buildWater(ctx) {
       distanceTexture: distTex,
       coverageTexture: coverageTex,
       seabedTexture: seabedTex,
+      hexSize: hexSizeWorld,
       hexW: hexW_est,
       hexH: hexH_est,
   gridW,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8484,6 +8484,9 @@
     "shared": {
       "name": "daemios-shared",
       "version": "0.1.0",
+      "dependencies": {
+        "simplex-noise": "^4.0.3"
+      },
       "devDependencies": {
         "vitest": "^3.2.4"
       }
@@ -10738,7 +10741,7 @@
         "daemios-api": "file:server",
         "daemios-shared": "file:shared",
         "daemios-web-client": "file:client",
-        "simplex-noise": "*"
+        "simplex-noise": "^4.0.3"
       },
       "dependencies": {
         "@babel/helper-string-parser": {
@@ -12700,6 +12703,7 @@
         "daemios-shared": {
           "version": "file:shared",
           "requires": {
+            "simplex-noise": "^4.0.3",
             "vitest": "^3.2.4"
           },
           "dependencies": {
@@ -16785,6 +16789,7 @@
     "daemios-shared": {
       "version": "file:shared",
       "requires": {
+        "simplex-noise": "^4.0.3",
         "vitest": "^3.2.4"
       },
       "dependencies": {


### PR DESCRIPTION
## Summary
- normalize the realistic and ghibli water materials around a shared `hexSize` uniform and consistent world-to-axial conversion
- derive the hex radius once in the water builder and forward it to shaders so water plane mapping matches terrain scaling
- update fallback setup and lockfile metadata to reflect the new uniform and dependency pin

## Testing
- npm --prefix client run lint *(fails: existing lint violations in unrelated files)*
- npm --prefix client run test:3d2 *(fails: vitest configuration file missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c94d2a57988327a7d577308bcce357