### PR TITLE
Fix water world mapping to ignore model scale

### DIFF
--- a/client/src/services/water/waterBuilder.js
+++ b/client/src/services/water/waterBuilder.js
@@ -6,7 +6,7 @@ import { DEFAULT_CONFIG } from '../../../../shared/lib/worldgen/config.js';
 import { BIOME_THRESHOLDS } from "@/3d2/domain/world/biomes";
 
 // Build water plane, mask and distance textures for a neighborhood.
-// ctx: { world, layoutRadius, spacingFactor, chunkCols, chunkRows, centerChunk, neighborRadius, hexMaxY, modelScaleFactor, heightMagnitude, elevation, profilerEnabled, profiler }
+// ctx: { world, layoutRadius, spacingFactor, chunkCols, chunkRows, centerChunk, neighborRadius, hexMaxY, heightMagnitude, elevation, profilerEnabled, profiler }
 export function buildWater(ctx) {
   const startTs =
     typeof performance !== "undefined" && performance.now
@@ -23,26 +23,23 @@ export function buildWater(ctx) {
     neighborRadius,
     hexMaxY,
     elevation,
-    modelScaleFactor,
   } = ctx;
 
   const radius = neighborRadius != null ? neighborRadius : 1;
 
   const layoutOpts = { layoutRadius, spacingFactor };
+  // Chunk geometry already applies any authoring scale, so world-space spacing
+  // comes directly from the layout helpers without an additional model scale.
   const baseHexSize = getHexSize(layoutOpts);
-  const scaleXZ =
-    typeof modelScaleFactor === "number" && Number.isFinite(modelScaleFactor) && modelScaleFactor > 0
-      ? modelScaleFactor
-      : 1;
   // Hex footprint in world units (center-to-center distance along axial basis)
-  const hexW_est = baseHexSize * scaleXZ * 1.5;
-  const hexH_est = baseHexSize * scaleXZ * Math.sqrt(3);
+  const hexW_est = baseHexSize * 1.5;
+  const hexH_est = baseHexSize * Math.sqrt(3);
 
   const axialToWorld = (q, r) => {
     const pos = axialToXZ(q, r, layoutOpts);
     return {
-      x: pos.x * scaleXZ,
-      z: pos.z * scaleXZ,
+      x: pos.x,
+      z: pos.z,
     };
   };
 


### PR DESCRIPTION
## Summary
- remove the extra modelScaleFactor multiplier when deriving water grid spacing so shader sampling uses the same world coordinates as terrain
- clarify that chunk geometry already applies any authoring scale before spacing is computed

## Testing
- npm run lint *(fails: Missing script "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68c94d2a57988327a7d577308bcce357