### PR TITLE
Implement worldgen infrastructure step 1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8484,6 +8484,9 @@
     "shared": {
       "name": "daemios-shared",
       "version": "0.1.0",
+      "dependencies": {
+        "simplex-noise": "^4.0.3"
+      },
       "devDependencies": {
         "vitest": "^3.2.4"
       }
@@ -10738,7 +10741,7 @@
         "daemios-api": "file:server",
         "daemios-shared": "file:shared",
         "daemios-web-client": "file:client",
-        "simplex-noise": "*"
+        "simplex-noise": "^4.0.3"
       },
       "dependencies": {
         "@babel/helper-string-parser": {
@@ -12700,6 +12703,7 @@
         "daemios-shared": {
           "version": "file:shared",
           "requires": {
+            "simplex-noise": "^4.0.3",
             "vitest": "^3.2.4"
           },
           "dependencies": {
@@ -16785,6 +16789,7 @@
     "daemios-shared": {
       "version": "file:shared",
       "requires": {
+        "simplex-noise": "^4.0.3",
         "vitest": "^3.2.4"
       },
       "dependencies": {

--- a/shared/lib/worldgen/utils/tileCache.js
+++ b/shared/lib/worldgen/utils/tileCache.js
@@ -1,0 +1,71 @@
+function normalizeKey(key) {
+  if (key === null || typeof key === 'undefined') return 'null';
+  if (typeof key === 'string' || typeof key === 'number' || typeof key === 'boolean') return String(key);
+  if (Array.isArray(key)) return key.map((part) => normalizeKey(part)).join('|');
+  if (typeof key === 'object') {
+    if (typeof key.key === 'string') return key.key;
+    if (typeof key.toString === 'function' && key.toString !== Object.prototype.toString) return key.toString();
+    try {
+      return JSON.stringify(key);
+    } catch (e) {
+      return String(key);
+    }
+  }
+  return String(key);
+}
+
+export class TileCache {
+  constructor() {
+    this._stores = new Map();
+  }
+
+  _getStore(name = 'default') {
+    const key = name || 'default';
+    if (!this._stores.has(key)) this._stores.set(key, new Map());
+    return this._stores.get(key);
+  }
+
+  get(store, key, factory) {
+    const storeMap = this._getStore(store);
+    const cacheKey = normalizeKey(key);
+    if (storeMap.has(cacheKey)) return storeMap.get(cacheKey);
+    const value = typeof factory === 'function' ? factory() : factory;
+    storeMap.set(cacheKey, value);
+    return value;
+  }
+
+  getWarp(key, factory) {
+    return this.get('warp', key, factory);
+  }
+
+  getVoronoi(key, factory) {
+    return this.get('voronoi', key, factory);
+  }
+
+  getValue(key, factory) {
+    return this.get('values', key, factory);
+  }
+
+  has(store, key) {
+    return this._getStore(store).has(normalizeKey(key));
+  }
+
+  set(store, key, value) {
+    this._getStore(store).set(normalizeKey(key), value);
+    return value;
+  }
+
+  clear(store) {
+    if (typeof store === 'string') {
+      this._stores.delete(store);
+    } else {
+      this._stores.clear();
+    }
+  }
+
+  stores() {
+    return Array.from(this._stores.keys());
+  }
+}
+
+export default { TileCache };

--- a/shared/lib/worldgen/utils/worldCoord.js
+++ b/shared/lib/worldgen/utils/worldCoord.js
@@ -1,0 +1,175 @@
+const SQRT3 = Math.sqrt(3);
+const BASE_HEX_SIZE = 2.0;
+const DEFAULT_LATITUDE_SCALE = BASE_HEX_SIZE * 96;
+
+function clamp(value, min, max) {
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
+}
+
+function axialToCube(q = 0, r = 0) {
+  const x = q;
+  const z = r;
+  const y = -x - z;
+  return { x, y, z };
+}
+
+function computeLatitudeNormalized(worldY, scale, method = 'tanh') {
+  if (!Number.isFinite(scale) || Math.abs(scale) < 1e-6) scale = 1;
+  const normalized = worldY / scale;
+  if (method === 'linear') return clamp(normalized, -1, 1);
+  if (method === 'atan') return clamp(Math.atan(normalized) / (Math.PI / 2), -1, 1);
+  return clamp(Math.tanh(normalized), -1, 1);
+}
+
+export class WorldCoord {
+  constructor(opts = {}) {
+    const {
+      q = 0,
+      r = 0,
+      layoutRadius = 1,
+      spacingFactor = 1,
+      hexSize,
+      latitudeScale,
+      latitudeMethod = 'tanh'
+    } = opts || {};
+
+    this.q = Number.isFinite(q) ? q : 0;
+    this.r = Number.isFinite(r) ? r : 0;
+    this.layoutRadius = Number.isFinite(layoutRadius) ? layoutRadius : 1;
+    this.spacingFactor = Number.isFinite(spacingFactor) ? spacingFactor : 1;
+
+    const resolvedHexSize = (typeof hexSize === 'number' && Number.isFinite(hexSize) && hexSize > 0)
+      ? hexSize
+      : BASE_HEX_SIZE * this.layoutRadius * this.spacingFactor;
+
+    this.hexSize = resolvedHexSize;
+
+    const worldX = resolvedHexSize * 1.5 * this.q;
+    const worldY = resolvedHexSize * SQRT3 * (this.r + this.q / 2);
+
+    this.x = worldX;
+    this.z = worldY;
+    this.y = worldY;
+
+    this.world = { x: worldX, y: worldY };
+    this.cube = axialToCube(this.q, this.r);
+
+    const baseLatScale = DEFAULT_LATITUDE_SCALE * (resolvedHexSize / BASE_HEX_SIZE);
+    this.latitudeScale = (typeof latitudeScale === 'number' && Number.isFinite(latitudeScale) && latitudeScale > 0)
+      ? latitudeScale
+      : baseLatScale;
+    this.latitudeMethod = latitudeMethod;
+
+    this.latitudeNormalized = computeLatitudeNormalized(this.world.y, this.latitudeScale, this.latitudeMethod);
+    this.latitude01 = (this.latitudeNormalized + 1) * 0.5;
+  }
+
+  get key() {
+    return `${this.q}:${this.r}`;
+  }
+
+  offset(dq = 0, dr = 0, extra = {}) {
+    return new WorldCoord({
+      q: this.q + (Number.isFinite(dq) ? dq : 0),
+      r: this.r + (Number.isFinite(dr) ? dr : 0),
+      layoutRadius: this.layoutRadius,
+      spacingFactor: this.spacingFactor,
+      hexSize: this.hexSize,
+      latitudeScale: this.latitudeScale,
+      latitudeMethod: this.latitudeMethod,
+      ...extra
+    });
+  }
+
+  distanceTo(other) {
+    if (!other) return 0;
+    const dx = this.x - other.x;
+    const dy = this.y - other.y;
+    return Math.sqrt(dx * dx + dy * dy);
+  }
+
+  axialDistanceTo(other) {
+    if (!other || !other.cube) return 0;
+    const a = this.cube;
+    const b = other.cube;
+    return Math.max(Math.abs(a.x - b.x), Math.abs(a.y - b.y), Math.abs(a.z - b.z));
+  }
+
+  bearingTo(other) {
+    if (!other) return 0;
+    const dx = other.x - this.x;
+    const dy = other.y - this.y;
+    return Math.atan2(dy, dx);
+  }
+
+  withLatitudeScale(newScale) {
+    const scale = (typeof newScale === 'number' && Number.isFinite(newScale) && newScale > 0)
+      ? newScale
+      : this.latitudeScale;
+    return new WorldCoord({
+      q: this.q,
+      r: this.r,
+      layoutRadius: this.layoutRadius,
+      spacingFactor: this.spacingFactor,
+      hexSize: this.hexSize,
+      latitudeScale: scale,
+      latitudeMethod: this.latitudeMethod
+    });
+  }
+
+  toObject() {
+    return {
+      q: this.q,
+      r: this.r,
+      x: this.x,
+      y: this.y,
+      z: this.z,
+      latitudeNormalized: this.latitudeNormalized,
+      latitude01: this.latitude01
+    };
+  }
+
+  toJSON() {
+    return this.toObject();
+  }
+
+  static axialToWorld(q = 0, r = 0, opts = {}) {
+    const {
+      layoutRadius = 1,
+      spacingFactor = 1,
+      hexSize
+    } = opts || {};
+    const resolvedHexSize = (typeof hexSize === 'number' && Number.isFinite(hexSize) && hexSize > 0)
+      ? hexSize
+      : BASE_HEX_SIZE * layoutRadius * spacingFactor;
+    return {
+      x: resolvedHexSize * 1.5 * q,
+      y: resolvedHexSize * SQRT3 * (r + q / 2)
+    };
+  }
+
+  static fromWorld(x = 0, y = 0, opts = {}) {
+    const { layoutRadius = 1, spacingFactor = 1, hexSize } = opts || {};
+    const resolvedHexSize = (typeof hexSize === 'number' && Number.isFinite(hexSize) && hexSize > 0)
+      ? hexSize
+      : BASE_HEX_SIZE * layoutRadius * spacingFactor;
+    const q = (2 / 3) * (x / resolvedHexSize);
+    const r = ((-1 / 3) * (x / resolvedHexSize)) + ((1 / SQRT3) * (y / resolvedHexSize));
+    return new WorldCoord({ q, r, layoutRadius, spacingFactor, hexSize: resolvedHexSize });
+  }
+}
+
+export function axialDistance(a, b) {
+  if (!a || !b) return 0;
+  const ac = a instanceof WorldCoord ? a.cube : axialToCube(a.q, a.r);
+  const bc = b instanceof WorldCoord ? b.cube : axialToCube(b.q, b.r);
+  return Math.max(Math.abs(ac.x - bc.x), Math.abs(ac.y - bc.y), Math.abs(ac.z - bc.z));
+}
+
+export function latitudeFromWorldY(worldY, scale, method = 'tanh') {
+  return computeLatitudeNormalized(worldY, scale, method);
+}
+
+export default { WorldCoord, axialDistance, latitudeFromWorldY };

--- a/shared/test/layer01-parity.test.js
+++ b/shared/test/layer01-parity.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { generateTile as sharedGenerate } from '../lib/worldgen/index.js';
+import { generateTile as sharedGenerate, WorldCoord } from '../lib/worldgen/index.js';
 import { computeTilePart as sharedCompute } from '../lib/worldgen/layers/layer01_continents.js';
 
 import { getDefaultConfig } from '../lib/worldgen/index.js';
@@ -12,7 +12,8 @@ describe('layer01 parity', () => {
     const samples = [ [0,0], [10,5], [23,-12] ];
     for (const [q, r] of samples) {
       const tile = sharedGenerate(seed, { q, r }, cfg);
-      const ctx = { seed: String(seed), q, r, cfg, rng: null, noise: null };
+      const coord = new WorldCoord({ q, r });
+      const ctx = { seed: String(seed), q, r, x: coord.x, z: coord.z, cfg, rng: null, noise: null, coord };
       const sharedPart = sharedCompute(ctx);
       // compare normalized elevation roughly
       const clientH = tile && tile.elevation && tile.elevation.normalized;

--- a/shared/worldgen/noise.js
+++ b/shared/worldgen/noise.js
@@ -1,25 +1,338 @@
 import * as SimplexNoiseModule from 'simplex-noise';
+
 const SimplexNoise = (SimplexNoiseModule && SimplexNoiseModule.default) || SimplexNoiseModule;
 
-const cache = new Map();
-const ATTRIBUTES = ['elevation', 'moisture', 'flora', 'passable', 'territory'];
+export const CORE_FIELDS = ['macro', 'warpSlow', 'warpFast', 'plateVoronoi', 'mediumDetail'];
+export const LEGACY_ATTRIBUTES = ['elevation', 'moisture', 'flora', 'passable', 'territory'];
 
-export function initNoise(seed = '') {
-  if (cache.has(seed)) return cache.get(seed);
-  const noises = {};
-  ATTRIBUTES.forEach((attr) => {
-    noises[attr] = new SimplexNoise(`${seed}:${attr}`);
-  });
-  cache.set(seed, noises);
-  return noises;
+const LEGACY_DEFAULT_SCALE = 0.05;
+const registryCache = new Map();
+
+function pickNumber(...values) {
+  for (const value of values) {
+    if (typeof value === 'number' && Number.isFinite(value)) return value;
+  }
+  return undefined;
 }
 
-export function sampleNoise(noises, x, y) {
-  const values = {};
-  Object.keys(noises).forEach((attr) => {
-    values[attr] = (noises[attr].noise2D(x * 0.05, y * 0.05) + 1) / 2;
-  });
-  return values;
+function defaultToUnit(value) {
+  return (value + 1) * 0.5;
 }
 
-export default { initNoise, sampleNoise };
+function createSimplexFactory(name) {
+  return ({ seed }) => new SimplexNoise(`${seed}:${name}`);
+}
+
+function createDefaultFieldMap(names) {
+  const entries = {};
+  for (const name of names) {
+    entries[name] = { factory: createSimplexFactory(name) };
+  }
+  return entries;
+}
+
+function wrapNoise(source, name) {
+  if (!source) throw new Error(`Noise source "${name}" is undefined.`);
+  if (typeof source === 'function') return { noise2D: source };
+  if (typeof source.noise2D === 'function') return source;
+  throw new Error(`Noise factory for "${name}" must return an object with a noise2D function.`);
+}
+
+function normalizeField(name, entry = {}) {
+  if (entry === null || typeof entry === 'undefined') entry = {};
+  if (typeof entry === 'string') return { alias: entry };
+  if (typeof entry.alias === 'string') {
+    const norm = { alias: entry.alias };
+    if (entry.metadata && typeof entry.metadata === 'object') norm.metadata = { ...entry.metadata };
+    return norm;
+  }
+
+  let instance = null;
+  if (typeof entry.noise2D === 'function') instance = entry;
+  else if (entry.instance && typeof entry.instance.noise2D === 'function') instance = entry.instance;
+  else if (entry.source && typeof entry.source.noise2D === 'function') instance = entry.source;
+  else if (entry.noise && typeof entry.noise.noise2D === 'function') instance = entry.noise;
+
+  let factory = null;
+  if (typeof entry.factory === 'function') factory = entry.factory;
+  else if (typeof entry === 'function') factory = entry;
+  else if (instance) factory = () => instance;
+  if (!factory) factory = createSimplexFactory(name);
+
+  const scale = pickNumber(entry.scale);
+  const transform = typeof entry.transform === 'function' ? entry.transform : undefined;
+  const toUnit = typeof entry.toUnit === 'function' ? entry.toUnit : undefined;
+  const metadata = entry && entry.metadata ? { ...entry.metadata } : {};
+  const aliases = Array.isArray(entry.aliases) ? entry.aliases.slice() : [];
+
+  return { factory, instance, scale, transform, toUnit, metadata, aliases };
+}
+
+export class NoiseSource {
+  constructor(name, config, registry) {
+    this.name = name;
+    this.registry = registry;
+    this.config = config || {};
+    this.metadata = { ...(this.config.metadata || {}) };
+    const raw = this.config.factory({ seed: registry.seed, name, registry });
+    this.noise = wrapNoise(raw, name);
+    this.noise2D = this.noise.noise2D.bind(this.noise);
+  }
+
+  sampleRaw(x, y, options = {}) {
+    const scale = pickNumber(options.scale, this.config.scale, this.registry.defaultScale, 1) ?? 1;
+    const sx = x * scale;
+    const sy = y * scale;
+    const value = this.noise2D(sx, sy);
+    const transform = options.transform ?? this.config.transform;
+    if (typeof transform === 'function') return transform(value, { x: sx, y: sy, source: this, registry: this.registry, options });
+    return value;
+  }
+
+  sample01(x, y, options = {}) {
+    const raw = this.sampleRaw(x, y, options);
+    const mapper = options.toUnit ?? this.config.toUnit ?? this.registry.defaultToUnit ?? defaultToUnit;
+    if (typeof mapper === 'function') return mapper(raw, { source: this, registry: this.registry, options });
+    return defaultToUnit(raw);
+  }
+}
+
+export class NoiseRegistry {
+  constructor(seed, options = {}) {
+    this.seed = String(seed ?? '');
+    this._fields = new Map();
+    this._aliases = new Map();
+    this._cache = new Map();
+    this.defaultScale = pickNumber(options.defaultScale, 1) ?? 1;
+    this.defaultToUnit = typeof options.defaultToUnit === 'function' ? options.defaultToUnit : defaultToUnit;
+    this.legacyAttributes = Array.isArray(options.legacyAttributes) && options.legacyAttributes.length
+      ? options.legacyAttributes.slice()
+      : LEGACY_ATTRIBUTES.slice();
+    this.coreFields = Array.isArray(options.coreFields) && options.coreFields.length
+      ? options.coreFields.slice()
+      : CORE_FIELDS.slice();
+
+    this.defineMany(createDefaultFieldMap([...this.coreFields, ...this.legacyAttributes]));
+    this.configure(options);
+  }
+
+  configure(options = {}) {
+    if (!options) return this;
+    if (options.fields) this.defineMany(options.fields);
+    if (options.aliases) {
+      for (const [alias, target] of Object.entries(options.aliases)) this.alias(alias, target);
+    }
+    if (Array.isArray(options.ensure)) options.ensure.forEach((name) => this.ensure(name));
+    if (Array.isArray(options.preload)) options.preload.forEach((name) => { this.getSource(name); });
+    return this;
+  }
+
+  defineMany(entries) {
+    if (!entries) return this;
+    if (Array.isArray(entries)) {
+      entries.forEach((entry) => {
+        if (entry && typeof entry === 'object' && typeof entry.name === 'string') this.define(entry.name, entry);
+      });
+      return this;
+    }
+    for (const [name, entry] of Object.entries(entries)) this.define(name, entry);
+    return this;
+  }
+
+  define(name, entry) {
+    if (!name && name !== 0) return this;
+    const normalized = normalizeField(String(name), entry || {});
+    if (normalized.alias) {
+      this.alias(name, normalized.alias);
+      return this;
+    }
+    this._fields.set(String(name), normalized);
+    if (Array.isArray(normalized.aliases)) normalized.aliases.forEach((alias) => this.alias(alias, name));
+    this._cache.delete(String(name));
+    return this;
+  }
+
+  ensure(name, entry) {
+    const key = String(name);
+    if (this._fields.has(key) || this._aliases.has(key)) return this;
+    return this.define(key, entry || {});
+  }
+
+  alias(aliasName, targetName) {
+    if (!aliasName && aliasName !== 0) return this;
+    if (!targetName && targetName !== 0) return this;
+    const aliasKey = String(aliasName);
+    const targetKey = String(targetName);
+    if (aliasKey === targetKey) return this;
+    this._aliases.set(aliasKey, targetKey);
+    this._cache.delete(aliasKey);
+    return this;
+  }
+
+  _resolveName(name) {
+    let current = String(name);
+    const visited = new Set();
+    while (this._aliases.has(current) && !visited.has(current)) {
+      visited.add(current);
+      current = this._aliases.get(current);
+    }
+    return current;
+  }
+
+  has(name) {
+    const key = this._resolveName(name);
+    return this._fields.has(key);
+  }
+
+  getField(name) {
+    const key = this._resolveName(name);
+    return this._fields.get(key);
+  }
+
+  getSource(name, fallback) {
+    const key = this._resolveName(name);
+    if (this._cache.has(key)) return this._cache.get(key);
+    let definition = this._fields.get(key);
+    if (!definition && fallback) {
+      definition = normalizeField(key, fallback);
+      this._fields.set(key, definition);
+    }
+    if (!definition) {
+      definition = normalizeField(key, {});
+      this._fields.set(key, definition);
+    }
+    const source = new NoiseSource(key, definition, this);
+    this._cache.set(key, source);
+    if (key !== name) this._cache.set(String(name), source);
+    return source;
+  }
+
+  get(name, fallback) {
+    return this.getSource(name, fallback);
+  }
+
+  clearCache(name) {
+    if (typeof name === 'string' || typeof name === 'number') {
+      this._cache.delete(this._resolveName(name));
+      this._cache.delete(String(name));
+    } else {
+      this._cache.clear();
+    }
+    return this;
+  }
+
+  sample(name, x, y, options = {}) {
+    return this.getSource(name).sampleRaw(x, y, options);
+  }
+
+  sample01(name, x, y, options = {}) {
+    return this.getSource(name).sample01(x, y, options);
+  }
+
+  sampleSet(names, x, y, options = {}) {
+    if (!Array.isArray(names)) return {};
+    const raw = options.raw === true;
+    const sampleOpts = { ...options };
+    delete sampleOpts.raw;
+    const values = {};
+    for (const name of names) {
+      values[name] = raw ? this.sample(name, x, y, sampleOpts) : this.sample01(name, x, y, sampleOpts);
+    }
+    return values;
+  }
+
+  sampleLegacy(x, y, options = {}) {
+    const names = Array.isArray(options.names) && options.names.length ? options.names : this.legacyAttributes;
+    const scale = pickNumber(options.scale, LEGACY_DEFAULT_SCALE) ?? LEGACY_DEFAULT_SCALE;
+    const raw = options.raw === true;
+    const sampleOpts = { ...options };
+    delete sampleOpts.names;
+    delete sampleOpts.scale;
+    delete sampleOpts.raw;
+    const px = x * scale;
+    const py = y * scale;
+    const result = {};
+    for (const name of names) {
+      result[name] = raw
+        ? this.sample(name, px, py, sampleOpts)
+        : this.sample01(name, px, py, sampleOpts);
+    }
+    return result;
+  }
+
+  names() {
+    const keys = new Set();
+    for (const key of this._fields.keys()) keys.add(key);
+    for (const key of this._aliases.keys()) keys.add(key);
+    return Array.from(keys);
+  }
+}
+
+const proxyHandler = {
+  get(target, prop, receiver) {
+    if (prop === '__registry__') return target;
+    if (prop === Symbol.toStringTag) return 'NoiseRegistry';
+    if (typeof prop === 'string' && !Reflect.has(target, prop)) {
+      return target.get(prop);
+    }
+    return Reflect.get(target, prop, receiver);
+  },
+  has(target, prop) {
+    if (typeof prop === 'string' && !Reflect.has(target, prop)) return target.has(prop);
+    return Reflect.has(target, prop);
+  },
+  ownKeys(target) {
+    const keys = new Set(Reflect.ownKeys(target));
+    target.names().forEach((name) => keys.add(name));
+    return Array.from(keys);
+  },
+  getOwnPropertyDescriptor(target, prop) {
+    if (Reflect.has(target, prop)) return Object.getOwnPropertyDescriptor(target, prop);
+    if (typeof prop === 'string' && target.has(prop)) {
+      return { configurable: true, enumerable: true, value: target.get(prop), writable: false };
+    }
+    return undefined;
+  }
+};
+
+function createRegistry(seed, options = {}) {
+  const registry = new NoiseRegistry(seed, options);
+  return new Proxy(registry, proxyHandler);
+}
+
+export function initNoise(seed = '', options = {}) {
+  const key = String(seed ?? '');
+  let proxy = registryCache.get(key);
+  if (!proxy) {
+    proxy = createRegistry(key, options);
+    registryCache.set(key, proxy);
+  } else if (options && typeof options === 'object' && options !== null) {
+    const registry = proxy.__registry__ || proxy;
+    if (registry && typeof registry.configure === 'function') registry.configure(options);
+  }
+  return proxy;
+}
+
+export function sampleNoise(noises, x, y, options = {}) {
+  if (!noises) return {};
+  if (typeof noises.sampleLegacy === 'function') return noises.sampleLegacy(x, y, options);
+  const scale = pickNumber(options.scale, LEGACY_DEFAULT_SCALE) ?? LEGACY_DEFAULT_SCALE;
+  const names = Array.isArray(options.names) && options.names.length ? options.names : LEGACY_ATTRIBUTES;
+  const px = x * scale;
+  const py = y * scale;
+  const result = {};
+  for (const name of names) {
+    const source = noises[name];
+    if (source && typeof source.sample01 === 'function') {
+      result[name] = source.sample01(px, py, options);
+    } else if (source && typeof source.noise2D === 'function') {
+      const raw = source.noise2D(px, py);
+      result[name] = defaultToUnit(raw);
+    } else {
+      result[name] = 0.5;
+    }
+  }
+  return result;
+}
+
+export default { initNoise, sampleNoise, NoiseRegistry, NoiseSource, CORE_FIELDS, LEGACY_ATTRIBUTES };


### PR DESCRIPTION
## Summary
- add a reusable `WorldCoord` helper for axial-to-world conversion, latitude normalization, and distance helpers
- introduce a tile-scoped cache and update the shared worldgen context to use the new coordinate helper and cached noise registry
- replace the shared noise helper with a lazy registry of named sources while keeping legacy sampling compatibility and adjust tests accordingly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb4098b62c8327bca76e4cee3367be