### PR TITLE
Implement macro geography layer 1 with shared caches

### DIFF
--- a/shared/lib/worldgen/config.js
+++ b/shared/lib/worldgen/config.js
@@ -23,13 +23,65 @@ export const DEFAULT_CONFIG = {
       paletteId: 'default'
     },
     layer1: {
-      continentScale: 1.0,
-      plateCellSize: 256,
-      warp: {
-        slow: { freq: 0.08, amp: 0.25 },
-        fast: { freq: 0.6, amp: 0.05 }
+      continentalMask: {
+        frequency: 0.0024,
+        octaves: 5,
+        lacunarity: 1.85,
+        gain: 0.45,
+        bias: -0.08,
+        power: 1.2,
+        preWarpBlend: 0.25
       },
-      detail: { freq: 0.6, amp: 0.15 }
+      warp: {
+        slow: { frequency: 0.0012, amplitude: 140 },
+        fast: { frequency: 0.0055, amplitude: 28 },
+        fastPower: 1.0
+      },
+      plates: {
+        cellSize: 520,
+        jitter: 0.75,
+        relaxation: 0.82,
+        ridgeWidth: 0.22,
+        ridgePower: 1.6,
+        ridgeHeight: 0.32,
+        ridgeNoiseFrequency: 0.0035,
+        ridgeNoiseAmplitude: 0.65,
+        trenchProbability: 0.32,
+        trenchHeight: 0.42,
+        trenchMultiplier: 1.8,
+        trenchNoiseFrequency: 0.0026,
+        trenchBias: -0.15
+      },
+      ridges: {
+        slopeScale: 0.75
+      },
+      mediumDetail: {
+        frequency: 0.014,
+        amplitude: 0.18,
+        octaves: 3,
+        lacunarity: 1.9,
+        gain: 0.5,
+        coastFalloff: 0.28,
+        coastExponent: 1.25,
+        plateFalloff: 0.45,
+        plateExponent: 0.65
+      },
+      combine: {
+        maskWeight: 1.0,
+        ridgeWeight: 0.6,
+        detailWeight: 0.35,
+        bias: 0.0
+      },
+      normalization: {
+        min: -1,
+        max: 1,
+        exponent: 1.0
+      },
+      ocean: {
+        depthScale: 1.5,
+        trenchScale: 2.2,
+        tieBreaker: 0.0005
+      }
     },
     layer2: {
       regionNoiseScale: 0.02,

--- a/shared/lib/worldgen/index.js
+++ b/shared/lib/worldgen/index.js
@@ -5,6 +5,9 @@
 import { DEFAULT_CONFIG } from './config.js';
 import { create as createRng } from './rng.js';
 import * as noise from './noiseUtils.js';
+import { ensureWorldCoord } from './utils/worldCoord.js';
+import { ensureTileCache } from './utils/tileCache.js';
+import { getNoiseRegistry } from './noiseRegistry.js';
 import { computeTilePart as PaletteCompute } from './layers/palette.js';
 import { computeTilePart as layer01Compute, fallback as layer01Fallback } from './layers/layer01_continents.js';
 import { computeTilePart as layer02Compute } from './layers/layer02_regions.js';
@@ -55,6 +58,9 @@ function generateTile(seed, coords = {}, cfgPartial) {
   }
   const cfg = normalizeConfig(cfgPartial);
   const ctx = { seed: String(seed), q, r, x, z, cfg, rng: createRng(seed, x, z), noise };
+  ctx.coord = ensureWorldCoord(ctx);
+  ctx.tileCache = ensureTileCache(ctx);
+  ctx.noiseRegistry = getNoiseRegistry(seed);
   const enabled = cfg._enabledLayers || {};
 
   // run layers in order; parts are partial tile outputs consumed by later layers
@@ -176,6 +182,9 @@ function sampleBlockLight(seed, qOrigin, rOrigin, S, cfgPartial) {
       // local x,z for layer samplers
       const { x, z } = axialToXZLocal(qW, rW);
       const ctx = { seed: String(seed), q: qW, r: rW, x, z, cfg, rng: createRng(seed, x, z), noise };
+      ctx.coord = ensureWorldCoord(ctx);
+      ctx.tileCache = ensureTileCache(ctx);
+      ctx.noiseRegistry = getNoiseRegistry(seed);
       let part1 = null;
       try {
         part1 = (typeof layer01Compute === 'function') ? layer01Compute(ctx) : (typeof layer01Fallback === 'function' ? layer01Fallback(ctx) : null);

--- a/shared/lib/worldgen/layers/layer01_continents.js
+++ b/shared/lib/worldgen/layers/layer01_continents.js
@@ -1,18 +1,12 @@
-/**
- * The goal of this file is produce a two specific 'passes' of noise to give the world it's basic
- * shape. The first pass is a macro continent pass that gives the world large landmasses
- * and oceans. The second pass is a finer detail pass that adds interesting mountains, hills, ravines,
- * and other LARGE terrain features.
- * 
- * To be clear, 'pass' here does not mean a single sample or function call, but rather
- * a conceptual pass that may involve multiple noise functions and layers blended together.
- * 
- */
+import { ensureWorldCoord } from '../utils/worldCoord.js';
+import { ensureTileCache } from '../utils/tileCache.js';
+import { getNoiseRegistry } from '../noiseRegistry.js';
 
-// (OLD) Layer 1: macro continents pass using a Voronoi/plate mask blended with low-frequency FBM
-
-import { fbm as fbmFactory } from '../noiseUtils.js';
-import { makeSimplex } from '../noiseFactory.js';
+function clamp(v, min, max) {
+  if (v <= min) return min;
+  if (v >= max) return max;
+  return v;
+}
 
 function seedStringToNumber(s) {
   let n = 0;
@@ -21,152 +15,305 @@ function seedStringToNumber(s) {
 }
 
 function pseudoRandom(ix, iy, seedNum) {
-  // simple deterministic hash -> 0..1
   const x = Math.sin((ix * 127.1 + iy * 311.7) + seedNum * 12.9898) * 43758.5453;
   return x - Math.floor(x);
 }
 
-function smoothstep(t) {
-  if (t <= 0) return 0;
-  if (t >= 1) return 1;
-  return t * t * (3 - 2 * t);
+function makePlateId(ix, iz, seedNum) {
+  const a = (ix * 73856093) ^ (iz * 19349663) ^ seedNum;
+  return Math.abs(a >>> 0);
 }
 
-function findNearestPlate(x, z, plateSize, seedNum) {
-  // plate grid coordinates
-  // use rounding so plate centers fall on multiples and origin can be inside a plate
-  const px = Math.round(x / plateSize);
-  const py = Math.round(z / plateSize);
-  let best = { dist: Infinity, cx: 0, cy: 0, ix: 0, iy: 0, rand: 0 };
-  // search neighboring plate cells (3x3) to approximate Voronoi
-  for (let oy = -1; oy <= 1; oy++) {
-    for (let ox = -1; ox <= 1; ox++) {
-      const ix = px + ox;
-      const iy = py + oy;
-      const pr = pseudoRandom(ix, iy, seedNum);
-      // jitter center within plate to avoid strict grid artifacts
-      const jitterX = (pr - 0.5) * plateSize * 0.5;
-      const jitterY = (pseudoRandom(ix, iy + 9999, seedNum) - 0.5) * plateSize * 0.5;
-      // anchor centers on grid multiples so small x/z ranges can intersect plates
-      const cx = ix * plateSize + jitterX;
-      const cy = iy * plateSize + jitterY;
-      const dx = x - cx;
-      const dz = z - cy;
-      const d = Math.sqrt(dx * dx + dz * dz);
-      if (d < best.dist) best = { dist: d, cx, cy, ix, iy, rand: pr };
+function ensureRegistry(ctx) {
+  if (ctx && ctx.noiseRegistry) return ctx.noiseRegistry;
+  const reg = getNoiseRegistry(ctx && ctx.seed);
+  if (ctx) ctx.noiseRegistry = reg;
+  return reg;
+}
+
+function computeWarps(ctx, coord, cfg, registry, tileCache) {
+  const warpCfg = cfg.warp || {};
+  const slowCfg = warpCfg.slow || {};
+  const fastCfg = warpCfg.fast || {};
+  const slow = tileCache.get('warp:slow', () => {
+    const amp = typeof slowCfg.amplitude === 'number' ? slowCfg.amplitude : 0;
+    if (!amp) return { x: 0, z: 0 };
+    const freq = typeof slowCfg.frequency === 'number' ? slowCfg.frequency : 0.001;
+    const simplex = registry.simplex('warpSlow');
+    const wx = simplex.noise2D(coord.x * freq, coord.z * freq) * amp;
+    const wz = simplex.noise2D((coord.x + 2000) * freq, (coord.z - 2000) * freq) * amp;
+    const power = typeof slowCfg.power === 'number' ? slowCfg.power : 1;
+    if (power !== 1 && power > 0) {
+      const mag = Math.sqrt(wx * wx + wz * wz) / Math.max(1e-6, amp);
+      const scale = Math.pow(clamp(mag, 0, 1), power - 1);
+      return { x: wx * scale, z: wz * scale };
     }
-  }
-  return best;
+    return { x: wx, z: wz };
+  });
+  const fast = tileCache.get('warp:fast', () => {
+    const amp = typeof fastCfg.amplitude === 'number' ? fastCfg.amplitude : 0;
+    if (!amp) return { x: 0, z: 0 };
+    const freq = typeof fastCfg.frequency === 'number' ? fastCfg.frequency : 0.004;
+    const simplex = registry.simplex('warpFast');
+    let wx = simplex.noise2D(coord.x * freq, coord.z * freq) * amp;
+    let wz = simplex.noise2D((coord.x - 4000) * freq, (coord.z + 4000) * freq) * amp;
+    const power = typeof fastCfg.power === 'number' ? fastCfg.power : (typeof warpCfg.fastPower === 'number' ? warpCfg.fastPower : 1);
+    if (power !== 1 && power > 0) {
+      const mag = Math.sqrt(wx * wx + wz * wz) / Math.max(1e-6, amp);
+      const scale = Math.pow(clamp(mag, 0, 1), power - 1);
+      wx *= scale;
+      wz *= scale;
+    }
+    return { x: wx, z: wz };
+  });
+  const combined = { x: slow.x + fast.x, z: slow.z + fast.z };
+  tileCache.set('warp:combined', combined);
+  return { slow, fast, combined };
+}
+
+function computeMask(coord, cfg, warps, registry) {
+  const maskCfg = cfg.continentalMask || {};
+  const sampler = registry.fbm('macro', {
+    octaves: typeof maskCfg.octaves === 'number' ? maskCfg.octaves : 5,
+    lacunarity: typeof maskCfg.lacunarity === 'number' ? maskCfg.lacunarity : 1.85,
+    gain: typeof maskCfg.gain === 'number' ? maskCfg.gain : 0.45,
+  });
+  const freq = typeof maskCfg.frequency === 'number' ? maskCfg.frequency : 0.0025;
+  const pre = sampler(coord.x * freq, coord.z * freq);
+  const preNorm = clamp(0.5 + 0.5 * pre, 0, 1);
+  const warpedX = coord.x + warps.combined.x;
+  const warpedZ = coord.z + warps.combined.z;
+  const post = sampler(warpedX * freq, warpedZ * freq);
+  const postNorm = clamp(0.5 + 0.5 * post, 0, 1);
+  const preWeight = clamp(typeof maskCfg.preWarpBlend === 'number' ? maskCfg.preWarpBlend : 0.25, 0, 1);
+  const blend = clamp(preNorm * preWeight + postNorm * (1 - preWeight), 0, 1);
+  const bias = typeof maskCfg.bias === 'number' ? maskCfg.bias : 0;
+  const biased = clamp(blend + bias, 0, 1);
+  const power = typeof maskCfg.power === 'number' ? maskCfg.power : 1.0;
+  const shaped = clamp(Math.pow(biased, Math.max(0.1, power)), 0, 1);
+  const signed = clamp(shaped * 2 - 1, -1, 1);
+  return { pre: preNorm, post: postNorm, blend, biased, shaped, signed };
+}
+
+function computePlateField(coord, cfg, seedNum, tileCache) {
+  return tileCache.get('plates:field', () => {
+    const plateCfg = cfg.plates || {};
+    const cellSize = Math.max(32, typeof plateCfg.cellSize === 'number' ? plateCfg.cellSize : 520);
+    const jitter = clamp(typeof plateCfg.jitter === 'number' ? plateCfg.jitter : 0.75, 0, 0.95);
+    const searchRadius = Math.max(1, typeof plateCfg.searchRadius === 'number' ? Math.floor(plateCfg.searchRadius) : 2);
+    const gx = Math.floor(coord.x / cellSize);
+    const gz = Math.floor(coord.z / cellSize);
+    let best = null;
+    let second = null;
+    for (let oz = -searchRadius; oz <= searchRadius; oz++) {
+      for (let ox = -searchRadius; ox <= searchRadius; ox++) {
+        const ix = gx + ox;
+        const iz = gz + oz;
+        const j1 = pseudoRandom(ix, iz, seedNum);
+        const j2 = pseudoRandom(ix + 1337, iz - 927, seedNum);
+        const centerX = (ix + 0.5) * cellSize + (j1 - 0.5) * jitter * cellSize;
+        const centerZ = (iz + 0.5) * cellSize + (j2 - 0.5) * jitter * cellSize;
+        const dx = coord.x - centerX;
+        const dz = coord.z - centerZ;
+        const dist = Math.sqrt(dx * dx + dz * dz);
+        const record = { dist, centerX, centerZ, ix, iz };
+        if (!best || dist < best.dist) {
+          second = best;
+          best = record;
+        } else if (!second || dist < second.dist) {
+          second = record;
+        }
+      }
+    }
+    if (!best) best = { dist: 0, centerX: coord.x, centerZ: coord.z, ix: gx, iz: gz };
+    if (!second) second = best;
+    const cellRadius = cellSize * 0.5;
+    const toEdge = Math.max(0, (second.dist - best.dist) * 0.5);
+    const relaxation = clamp(typeof plateCfg.relaxation === 'number' ? plateCfg.relaxation : 0.82, 0.1, 4);
+    const edgeDistanceNormalized = clamp(toEdge / Math.max(1e-6, cellRadius * relaxation), 0, 1);
+    const plateId = makePlateId(best.ix, best.iz, seedNum);
+    const neighborId = makePlateId(second.ix, second.iz, seedNum);
+    const nx = second.centerX - best.centerX;
+    const nz = second.centerZ - best.centerZ;
+    const nLen = Math.sqrt(nx * nx + nz * nz) || 1;
+    const edgeNormal = { x: nx / nLen, z: nz / nLen };
+    const midpoint = { x: (best.centerX + second.centerX) * 0.5, z: (best.centerZ + second.centerZ) * 0.5 };
+    const ridgeSeed = (plateId ^ ((neighborId << 1) | (neighborId >>> 1))) >>> 0;
+    return {
+      id: plateId,
+      neighborId,
+      cellSize,
+      center: { x: best.centerX, z: best.centerZ },
+      secondCenter: { x: second.centerX, z: second.centerZ },
+      distanceToCenter: best.dist,
+      distanceToEdge: toEdge,
+      edgeDistanceNormalized,
+      edgeNormal,
+      midpoint,
+      ridgeSeed,
+    };
+  });
+}
+
+function computeRidgeField(cfg, registry, warpedCoord, plateField) {
+  const plateCfg = cfg.plates || {};
+  const ridgeWidth = Math.max(1e-3, typeof plateCfg.ridgeWidth === 'number' ? plateCfg.ridgeWidth : 0.22);
+  const ridgePower = typeof plateCfg.ridgePower === 'number' ? plateCfg.ridgePower : 1.6;
+  const base = clamp(1 - plateField.distanceToEdge / Math.max(1e-6, plateField.cellSize * ridgeWidth), 0, 1);
+  const shaped = Math.pow(base, ridgePower);
+  const ridgeNoiseFreq = typeof plateCfg.ridgeNoiseFrequency === 'number' ? plateCfg.ridgeNoiseFrequency : 0.0035;
+  const ridgeNoiseAmp = typeof plateCfg.ridgeNoiseAmplitude === 'number' ? plateCfg.ridgeNoiseAmplitude : 0.65;
+  const ridgeNoise = registry.fbm('plateRidge', { octaves: 2, lacunarity: 2.1, gain: 0.55 });
+  const noiseVal = ridgeNoise(warpedCoord.x * ridgeNoiseFreq, warpedCoord.z * ridgeNoiseFreq);
+  const strength = clamp(shaped * (1 + noiseVal * ridgeNoiseAmp), 0, 1);
+  const trenchFreq = typeof plateCfg.trenchNoiseFrequency === 'number' ? plateCfg.trenchNoiseFrequency : 0.0026;
+  const trenchBias = typeof plateCfg.trenchBias === 'number' ? plateCfg.trenchBias : 0;
+  const trenchProb = clamp(typeof plateCfg.trenchProbability === 'number' ? plateCfg.trenchProbability : 0.3, 0, 1);
+  const trenchThreshold = trenchProb * 2 - 1;
+  const trenchNoise = registry.simplex('plateTrench');
+  const trenchVal = trenchNoise.noise2D(plateField.midpoint.x * trenchFreq, plateField.midpoint.z * trenchFreq) + trenchBias;
+  const isTrench = trenchVal < trenchThreshold;
+  const ridgeHeight = isTrench
+    ? (typeof plateCfg.trenchHeight === 'number' ? plateCfg.trenchHeight : 0.42)
+    : (typeof plateCfg.ridgeHeight === 'number' ? plateCfg.ridgeHeight : 0.32);
+  const contribution = strength * ridgeHeight * (isTrench ? -1 : 1);
+  const oceanMultiplier = isTrench ? (typeof plateCfg.trenchMultiplier === 'number' ? plateCfg.trenchMultiplier : 1.8) : 1;
+  return { strength, contribution, isTrench, oceanMultiplier, trenchVal };
+}
+
+function computeMediumDetail(cfg, registry, warpedCoord, plateField, maskValue, seaLevel) {
+  const detailCfg = cfg.mediumDetail || {};
+  const freq = typeof detailCfg.frequency === 'number' ? detailCfg.frequency : 0.014;
+  const amp = typeof detailCfg.amplitude === 'number' ? detailCfg.amplitude : 0.18;
+  const sampler = registry.fbm('mediumDetail', {
+    octaves: typeof detailCfg.octaves === 'number' ? detailCfg.octaves : 3,
+    lacunarity: typeof detailCfg.lacunarity === 'number' ? detailCfg.lacunarity : 1.9,
+    gain: typeof detailCfg.gain === 'number' ? detailCfg.gain : 0.5,
+  });
+  const sample = sampler(warpedCoord.x * freq, warpedCoord.z * freq);
+  const coastFalloff = Math.max(1e-4, typeof detailCfg.coastFalloff === 'number' ? detailCfg.coastFalloff : 0.28);
+  const coastExp = typeof detailCfg.coastExponent === 'number' ? detailCfg.coastExponent : 1.25;
+  const plateFalloff = Math.max(1e-4, typeof detailCfg.plateFalloff === 'number' ? detailCfg.plateFalloff : 0.45);
+  const plateExp = typeof detailCfg.plateExponent === 'number' ? detailCfg.plateExponent : 0.65;
+  const coastDistance = Math.abs(maskValue - seaLevel);
+  const coastWeight = clamp(Math.pow(clamp(coastDistance / coastFalloff, 0, 1), coastExp), 0, 1);
+  const plateWeight = clamp(Math.pow(clamp(plateField.edgeDistanceNormalized / plateFalloff, 0, 1), plateExp), 0, 1);
+  const weight = clamp(coastWeight * plateWeight, 0, 1);
+  const contribution = sample * amp * weight;
+  return { sample, contribution, weight };
+}
+
+function combineElevation(mask, ridgeField, mediumDetail, cfg) {
+  const combineCfg = cfg.combine || {};
+  const maskWeight = typeof combineCfg.maskWeight === 'number' ? combineCfg.maskWeight : 1.0;
+  const ridgeWeight = typeof combineCfg.ridgeWeight === 'number' ? combineCfg.ridgeWeight : 0.6;
+  const detailWeight = typeof combineCfg.detailWeight === 'number' ? combineCfg.detailWeight : 0.35;
+  const bias = typeof combineCfg.bias === 'number' ? combineCfg.bias : 0;
+  let signed = mask.signed * maskWeight;
+  signed += ridgeField.contribution * ridgeWeight;
+  signed += mediumDetail.contribution * detailWeight;
+  signed += bias;
+  return signed;
+}
+
+function normalizeElevation(value, cfg) {
+  const norm = cfg.normalization || {};
+  const minN = typeof norm.min === 'number' ? norm.min : -1;
+  const maxN = typeof norm.max === 'number' ? norm.max : 1;
+  const clamped = clamp(value, minN, maxN);
+  let normalized = clamp((clamped - minN) / Math.max(1e-6, maxN - minN), 0, 1);
+  const exp = typeof norm.exponent === 'number' ? norm.exponent : 1;
+  if (exp !== 1 && exp > 0) normalized = Math.pow(normalized, exp);
+  return { clamped, normalized };
+}
+
+function computeSlope(ridgeField, mediumDetail, cfg) {
+  const ridgeScale = (cfg.ridges && typeof cfg.ridges.slopeScale === 'number') ? cfg.ridges.slopeScale : 0.75;
+  const mediumSlope = Math.abs(mediumDetail.contribution) * 2.2;
+  const ridgeSlope = ridgeField.strength * ridgeScale;
+  return clamp(ridgeSlope + mediumSlope, 0, 1);
+}
+
+function tieBreakWater(delta, coord, seedNum, threshold) {
+  if (Math.abs(delta) > threshold) return delta < 0;
+  const jitter = pseudoRandom(Math.floor(coord.x), Math.floor(coord.z), seedNum);
+  return jitter < 0.5;
 }
 
 function computeTilePart(ctx) {
-  const cfg = (ctx.cfg && ctx.cfg.layers && ctx.cfg.layers.layer1) ? ctx.cfg.layers.layer1 : {};
-  // Larger plate size for big continents (default set in DEFAULT_CONFIG)
-  const plateSizeBase = (typeof cfg.plateCellSize === 'number') ? cfg.plateCellSize : 512;
-  const plateSize = Math.max(1, Math.round(plateSizeBase * (typeof cfg.continentScale === 'number' ? cfg.continentScale : 1)));
-
-  // Use a single global-noise sampler (seeded only by the world seed) so sampling
-  // across tiles is continuous. Passing q,r to makeSimplex creates per-tile noise
-  // functions which breaks continuity and produces stripes/artifacts.
-  const noise = makeSimplex(String(ctx.seed));
-
-  // Stricter macro: single-octave FBM and lower gain so macro is very smooth.
-  const fbmCfg = cfg.fbm || { octaves: 1, lacunarity: 1.8, gain: 0.3 };
-  const macroOctaves = Math.max(1, (fbmCfg.octaves ? Math.max(1, Math.floor(fbmCfg.octaves)) : 1));
-  const macroSampler = fbmFactory(noise, macroOctaves, fbmCfg.lacunarity || 1.8, fbmCfg.gain || 0.3);
-
-  // Simple Cartesian scaling for macro sampler
-  const sx = ctx.x / plateSize;
-  const sy = ctx.z / plateSize;
-  // Avoid domain warp for the macro pass (it injects high-frequency energy)
-  const v = macroSampler(sx, sy); // -1..1
-  const macro = Math.max(0, Math.min(1, (v + 1) / 2));
-
-  // Single-pass macro: use the FBM output directly (no Voronoi plates or neighbor smoothing)
-  const blended = Math.max(0, Math.min(1, macro));
-
-  // Optional slight smoothing by nudging toward neighbor plate centers is possible later
-
-  // remap into water vs land bands
-  // prefer global sea level from ctx.cfg.layers.global.seaLevel for authoritative value
+  const cfg = (ctx && ctx.cfg && ctx.cfg.layers && ctx.cfg.layers.layer1) ? ctx.cfg.layers.layer1 : {};
+  const coord = ensureWorldCoord(ctx);
+  const tileCache = ensureTileCache(ctx);
+  const registry = ensureRegistry(ctx);
+  const warps = computeWarps(ctx, coord, cfg, registry, tileCache);
+  const mask = computeMask(coord, cfg, warps, registry);
+  const seedNum = seedStringToNumber(String(ctx.seed || ''));
+  const plateField = computePlateField(coord, cfg, seedNum, tileCache);
+  const warpedCoord = { x: coord.x + warps.combined.x, z: coord.z + warps.combined.z };
+  const ridgeField = computeRidgeField(cfg, registry, warpedCoord, plateField);
   const seaLevel = (ctx && ctx.cfg && ctx.cfg.layers && ctx.cfg.layers.global && typeof ctx.cfg.layers.global.seaLevel === 'number')
     ? ctx.cfg.layers.global.seaLevel
-    : (typeof cfg.seaLevel === 'number' ? cfg.seaLevel : 0.52);
-  // shallowBand is the fixed top of the water gradient (0..1). Use a small
-  // constant so that changing seaLevel only affects classification thresholds
-  // and palette blending, not absolute tile heights.
-  const shallowBand = (typeof cfg.shallowBand === 'number') ? cfg.shallowBand : 0.26;
-  const landMax = (typeof cfg.landMax === 'number') ? cfg.landMax : 0.55; // cap for this layer
-  const threshold = (typeof cfg.threshold === 'number') ? cfg.threshold : 0.46; // start of land band
-
-  let h = 0;
-  if (blended <= threshold) {
-    // Apply an optional dampening function so low macro values trend
-    // strongly toward the minimum/base elevation. This produces
-    // gentler slopes out of the seafloor instead of uniformly raised
-    // ocean floors when the macro FBM skews high.
-    const dampThreshold = (typeof cfg.dampThreshold === 'number') ? cfg.dampThreshold : 0.25;
-    const dampPower = (typeof cfg.dampPower === 'number') ? cfg.dampPower : 2.5;
-    const dampScale = (typeof cfg.dampScale === 'number') ? cfg.dampScale : 1.0;
-
-  if (blended <= dampThreshold) {
-      // Strong attenuation near the minimum: normalized t in [0,1]
-      const t = blended / Math.max(1e-9, dampThreshold);
-      const atten = Math.pow(t, dampPower);
-      // Map attenuated value into ocean band (0..seaLevel), scaled by dampScale
-  h = atten * shallowBand * dampScale;
-    } else {
-      // For intermediate ocean values between dampThreshold and threshold,
-      // interpolate smoothly from the attenuated dampThreshold output up to
-      // the previous linear mapping at `threshold` so slopes aren't abrupt.
-      const t = (blended - dampThreshold) / Math.max(1e-9, threshold - dampThreshold);
-      const dampedBase = Math.pow(dampThreshold / Math.max(1e-9, dampThreshold), dampPower) * shallowBand * dampScale; // effectively 0 but kept for clarity
-      const linearAtThreshold = shallowBand; // top of shallow/ocean band
-      // lerp between dampedBase and linearAtThreshold
-      h = dampedBase + t * (linearAtThreshold - dampedBase);
-    }
-  } else {
-    const t = (blended - threshold) / (1 - threshold);
-    const s = smoothstep(t);
-    // Map land portion into shallowBand..landMax so heights remain in a
-    // consistent scale regardless of seaLevel value.
-    h = shallowBand + s * (landMax - shallowBand);
-  }
-
-  h = Math.max(0, Math.min(1, h));
-
-  const isWater = h <= seaLevel;
-  const depthBand = isWater ? (h < seaLevel - 0.12 ? 'deep' : 'shallow') : 'land';
-  const plateId = null;
-  const edgeDistance = 1;
-
+    : 0.22;
+  const mediumDetail = computeMediumDetail(cfg, registry, warpedCoord, plateField, mask.shaped, seaLevel);
+  const signedElevation = combineElevation(mask, ridgeField, mediumDetail, cfg);
+  const normalized = normalizeElevation(signedElevation, cfg);
+  const oceanCfg = cfg.ocean || {};
+  const depthScale = typeof oceanCfg.depthScale === 'number' ? oceanCfg.depthScale : 1.5;
+  const trenchScale = typeof oceanCfg.trenchScale === 'number' ? oceanCfg.trenchScale : 2.2;
+  const tieThreshold = typeof oceanCfg.tieBreaker === 'number' ? Math.max(0, oceanCfg.tieBreaker) : 0;
+  const delta = normalized.normalized - seaLevel;
+  const isWater = tieBreakWater(delta, coord, seedNum, tieThreshold);
+  const oceanDepth = isWater ? Math.max(0, seaLevel - normalized.normalized) * depthScale * (ridgeField.isTrench ? trenchScale : 1) : 0;
+  const depthBand = isWater ? (normalized.normalized < seaLevel - 0.12 ? 'deep' : 'shallow') : 'land';
+  const slope = computeSlope(ridgeField, mediumDetail, cfg);
+  const edgeDistance = clamp(plateField.edgeDistanceNormalized, 0, 1);
   return {
-    elevation: { raw: h, normalized: h },
+    elevation: { raw: normalized.normalized, normalized: normalized.normalized },
+    macroElevation: normalized.normalized,
+    plateId: plateField.id,
+    ridgeStrength: clamp(ridgeField.strength, 0, 1),
+    oceanDepth,
     bathymetry: { depthBand, seaLevel },
-    slope: 0.0,
-    plate: { id: plateId, edgeDistance }
+    slope,
+    plate: {
+      id: plateField.id,
+      edgeDistance,
+      edgeNormal: plateField.edgeNormal,
+      ridgeSeed: plateField.ridgeSeed,
+    },
+    plateEdgeDistance: edgeDistance,
+    debug: {
+      mask,
+      warps,
+      ridge: ridgeField,
+      mediumDetail,
+      signedElevation,
+      clampedElevation: normalized.clamped,
+    },
   };
 }
 
-// fallback deterministic shallow pattern when layer is disabled
 function fallback(ctx) {
-  const cfg = (ctx.cfg && ctx.cfg.layers && ctx.cfg.layers.layer1) ? ctx.cfg.layers.layer1 : {};
-  const plateSize = cfg.plateCellSize || 256;
-  // cheap deterministic pattern
-  const v = Math.abs(Math.sin((ctx.x * 12.9898 + ctx.z * 78.233) % 1));
-  const base = Math.max(0, Math.min(1, v));
+  const cfg = (ctx && ctx.cfg && ctx.cfg.layers && ctx.cfg.layers.layer1) ? ctx.cfg.layers.layer1 : {};
+  const coord = ensureWorldCoord(ctx);
+  const seedNum = seedStringToNumber(String(ctx.seed || ''));
+  const plateSize = (cfg.plates && typeof cfg.plates.cellSize === 'number') ? cfg.plates.cellSize : 256;
+  const v = Math.abs(Math.sin((coord.x * 12.9898 + coord.z * 78.233) % 1));
+  const base = clamp(v, 0, 1);
   const seaLevel = (typeof cfg.seaLevel === 'number') ? cfg.seaLevel : 0.52;
-  const shallowBandFallback = (typeof cfg.shallowBand === 'number') ? cfg.shallowBand : 0.26;
-  const h = base * shallowBandFallback * 0.9; // keep fallback under shallowBand mostly
-  const isWater = h <= seaLevel;
-  const depthBand = isWater ? 'shallow' : 'land';
-  const plateId = Math.abs(Math.floor((ctx.x + ctx.z) / plateSize));
-  const edgeDistance = Math.abs((ctx.x + ctx.z) % plateSize - (plateSize / 2)) / plateSize;
+  const shallowBandFallback = (cfg.continentalMask && typeof cfg.continentalMask.shallowBand === 'number') ? cfg.continentalMask.shallowBand : 0.26;
+  const h = base * shallowBandFallback * 0.9;
+  const depthBand = h <= seaLevel ? 'shallow' : 'land';
+  const plateId = makePlateId(Math.floor(coord.x / Math.max(1, plateSize)), Math.floor(coord.z / Math.max(1, plateSize)), seedNum);
+  const edgeDistance = clamp(Math.abs((coord.x + coord.z) % plateSize - (plateSize / 2)) / Math.max(1, plateSize), 0, 1);
   return {
     elevation: { raw: h, normalized: h },
     bathymetry: { depthBand, seaLevel },
     slope: 0.0,
-    plate: { id: plateId, edgeDistance }
+    plate: { id: plateId, edgeDistance },
+    plateId,
+    ridgeStrength: 0,
+    oceanDepth: Math.max(0, seaLevel - h),
   };
 }
 

--- a/shared/lib/worldgen/noiseRegistry.js
+++ b/shared/lib/worldgen/noiseRegistry.js
@@ -1,0 +1,67 @@
+// shared/lib/worldgen/noiseRegistry.js
+// Centralized registry for lazily-instantiated noise sources keyed by a
+// world seed and logical name. Layers use this to share deterministic
+// samplers without re-seeding Simplex/FBM on every tile.
+
+import { makeSimplex } from './noiseFactory.js';
+import { fbm as fbmFactory } from './noiseUtils.js';
+
+function clamp(v, min, max) {
+  if (v <= min) return min;
+  if (v >= max) return max;
+  return v;
+}
+
+function optsKey(opts = {}) {
+  const o = opts || {};
+  const oct = typeof o.octaves === 'number' ? clamp(Math.floor(o.octaves), 1, 16) : 'd';
+  const lac = typeof o.lacunarity === 'number' ? Number(o.lacunarity).toFixed(3) : 'd';
+  const gain = typeof o.gain === 'number' ? Number(o.gain).toFixed(3) : 'd';
+  return `${oct}:${lac}:${gain}`;
+}
+
+class NoiseRegistry {
+  constructor(seed = '') {
+    this.seed = String(seed || '');
+    this.cache = new Map();
+  }
+
+  _key(type, name, extra = '') {
+    return `${type}:${name}:${extra}`;
+  }
+
+  simplex(name) {
+    const key = this._key('simplex', name, '');
+    if (this.cache.has(key)) return this.cache.get(key);
+    const sampler = makeSimplex(`${this.seed}:${name}`, 0, 0);
+    this.cache.set(key, sampler);
+    return sampler;
+  }
+
+  fbm(name, opts = {}) {
+    const ok = optsKey(opts);
+    const key = this._key('fbm', name, ok);
+    if (this.cache.has(key)) return this.cache.get(key);
+    const simplex = this.simplex(name);
+    const octaves = typeof opts.octaves === 'number' ? clamp(Math.floor(opts.octaves), 1, 12) : 4;
+    const lacunarity = typeof opts.lacunarity === 'number' ? opts.lacunarity : 2.0;
+    const gain = typeof opts.gain === 'number' ? opts.gain : 0.5;
+    const sampler = fbmFactory(simplex, octaves, lacunarity, gain);
+    const fn = (x, y) => sampler(x, y);
+    fn._meta = { octaves, lacunarity, gain };
+    this.cache.set(key, fn);
+    return fn;
+  }
+}
+
+const REGISTRY_CACHE = new Map();
+
+function getNoiseRegistry(seed = '') {
+  const key = String(seed || '');
+  if (REGISTRY_CACHE.has(key)) return REGISTRY_CACHE.get(key);
+  const reg = new NoiseRegistry(key);
+  REGISTRY_CACHE.set(key, reg);
+  return reg;
+}
+
+export { NoiseRegistry, getNoiseRegistry };

--- a/shared/lib/worldgen/utils/tileCache.js
+++ b/shared/lib/worldgen/utils/tileCache.js
@@ -1,0 +1,38 @@
+// shared/lib/worldgen/utils/tileCache.js
+// Lightweight helper for memoizing expensive per-tile computations within
+// a layer. Each tile evaluation gets its own TileCache instance so cached
+// values remain deterministic and side-effect free.
+
+class TileCache {
+  constructor() {
+    this._map = new Map();
+  }
+
+  get(key, factory) {
+    if (this._map.has(key)) return this._map.get(key);
+    if (typeof factory === 'function') {
+      const value = factory();
+      this._map.set(key, value);
+      return value;
+    }
+    return undefined;
+  }
+
+  set(key, value) {
+    this._map.set(key, value);
+    return value;
+  }
+
+  has(key) {
+    return this._map.has(key);
+  }
+}
+
+function ensureTileCache(ctx) {
+  if (ctx && ctx.tileCache instanceof TileCache) return ctx.tileCache;
+  const cache = new TileCache();
+  if (ctx) ctx.tileCache = cache;
+  return cache;
+}
+
+export { TileCache, ensureTileCache };

--- a/shared/lib/worldgen/utils/worldCoord.js
+++ b/shared/lib/worldgen/utils/worldCoord.js
@@ -1,0 +1,69 @@
+// shared/lib/worldgen/utils/worldCoord.js
+// Axial (q, r) -> Cartesian helper with deterministic normalization helpers.
+
+function clamp(v, min, max) {
+  if (v <= min) return min;
+  if (v >= max) return max;
+  return v;
+}
+
+class WorldCoord {
+  constructor(q = 0, r = 0, opts = {}) {
+    this.q = typeof q === 'number' ? q : 0;
+    this.r = typeof r === 'number' ? r : 0;
+    this.hexSize = typeof opts.hexSize === 'number' ? opts.hexSize : 2.0;
+    if (typeof opts.x === 'number' && typeof opts.z === 'number') {
+      this.x = opts.x;
+      this.z = opts.z;
+    } else {
+      const size = this.hexSize;
+      this.x = size * 1.5 * this.q;
+      this.z = size * Math.sqrt(3) * (this.r + this.q / 2);
+    }
+    this.latitudeScale = typeof opts.latitudeScale === 'number' ? opts.latitudeScale : 2400;
+    this.radiusScale = typeof opts.radiusScale === 'number' ? opts.radiusScale : 4200;
+  }
+
+  clone() {
+    return new WorldCoord(this.q, this.r, {
+      hexSize: this.hexSize,
+      x: this.x,
+      z: this.z,
+      latitudeScale: this.latitudeScale,
+      radiusScale: this.radiusScale,
+    });
+  }
+
+  get normalizedLatitude() {
+    const scale = Math.max(1e-6, this.latitudeScale);
+    return clamp(this.z / scale, -1, 1);
+  }
+
+  get radialDistance() {
+    return Math.sqrt(this.x * this.x + this.z * this.z);
+  }
+
+  get normalizedDistance() {
+    const scale = Math.max(1e-6, this.radiusScale);
+    return clamp(this.radialDistance / scale, 0, 1);
+  }
+}
+
+function ensureWorldCoord(ctx) {
+  if (ctx && ctx.coord instanceof WorldCoord) return ctx.coord;
+  const q = ctx && typeof ctx.q === 'number' ? ctx.q : 0;
+  const r = ctx && typeof ctx.r === 'number' ? ctx.r : 0;
+  const opts = {};
+  if (ctx && typeof ctx.x === 'number' && typeof ctx.z === 'number') {
+    opts.x = ctx.x;
+    opts.z = ctx.z;
+  }
+  if (ctx && typeof ctx.hexSize === 'number') opts.hexSize = ctx.hexSize;
+  if (ctx && typeof ctx.latitudeScale === 'number') opts.latitudeScale = ctx.latitudeScale;
+  if (ctx && typeof ctx.radiusScale === 'number') opts.radiusScale = ctx.radiusScale;
+  const coord = new WorldCoord(q, r, opts);
+  if (ctx) ctx.coord = coord;
+  return coord;
+}
+
+export { WorldCoord, ensureWorldCoord };


### PR DESCRIPTION
## Summary
- add deterministic noise registry, world coordinate helper, and per-tile cache utilities for shared worldgen layers
- rebuild layer 1 macro geography to produce warped continental masks, plate distances, ridge fields, and cached macro elevation outputs
- expand the default layer 1 configuration for mask, warp, plate, ridge, and normalization tunables

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb5949841883279d1a50e4b7ad4ca5