### PR TITLE
Add missing shared enums and restore server broadcast test

### DIFF
--- a/server/test/broadcast.test.js
+++ b/server/test/broadcast.test.js
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import { WebSocket } from 'ws';
+import wss from '../src/lib/socket.js';
+
+const messages = [];
+const openClient = { readyState: WebSocket.OPEN, send: message => messages.push(message) };
+const closedClient = { readyState: WebSocket.CLOSED, send: () => {
+  throw new Error('send should not be called on closed client');
+} };
+
+const clients = wss.clients;
+clients.add(openClient);
+clients.add(closedClient);
+
+try {
+  const payload = { hello: 'world' };
+  wss.send('TEST', payload);
+  assert.deepEqual(messages, [JSON.stringify({ type: 'TEST', body: payload })]);
+} finally {
+  clients.clear();
+  await new Promise((resolve, reject) => {
+    wss.close(err => (err ? reject(err) : resolve()));
+  });
+}

--- a/shared/types/enums.ts
+++ b/shared/types/enums.ts
@@ -4,6 +4,25 @@
  * These arrays are deliberately declared with `as const` so that both runtime
  * consumers and TypeScript can rely on the literal union types.
  */
+export const ContainerTypes = ['BASIC', 'LIQUID', 'CONSUMABLES', 'PACK', 'POCKETS'] as const;
+
+export type ContainerType = (typeof ContainerTypes)[number];
+
+export const EquipmentSlot = [
+  'BACKPACK',
+  'BELT',
+  'BANDOLIER',
+  'LEG',
+  'HEAD',
+  'CHEST',
+  'HANDS',
+  'FEET',
+  'TRINKET1',
+  'TRINKET2',
+] as const;
+
+export type EquipmentSlot = (typeof EquipmentSlot)[number];
+
 export const WorldLocationTypes = ['TOWN', 'DUNGEON', 'QUEST'] as const;
 
 export type WorldLocationType = (typeof WorldLocationTypes)[number];


### PR DESCRIPTION
## Summary
- add shared enum definitions for container types and equipment slots to keep Prisma and TypeScript values aligned
- reintroduce a minimal broadcast test to exercise the WebSocket broadcast helper

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3f83cbc7c8327a00c1077efe431db