### PR TITLE
Remove verbose logging from water builder helper

### DIFF
--- a/client/src/services/water/waterBuilder.js
+++ b/client/src/services/water/waterBuilder.js
@@ -81,12 +81,7 @@ export function buildWater(ctx) {
 
   const data = new Uint8Array(N * N * 4);
   const seabed = new Uint8Array(N * N * 4);
-  // perf helper
-  const perfNow = () => (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
-  const tFillStart = perfNow();
   let idx = 0;
-  let fillWaterCount = 0;
-  let fillLandCount = 0;
   // track neighborhood stats during the fill pass to avoid a second generator sweep
   let minTop = Infinity;
   let minTopWater = Infinity;
@@ -94,16 +89,15 @@ export function buildWater(ctx) {
   // Attempt to use bulk sampling API when available on the world/generator to avoid
   // per-cell generator calls. Fall back to the old per-cell loop if not present or on error.
   let usedBulk = false;
-  let _blkSample = null;
   try {
     if (world && typeof world.sampleBlock === 'function') {
       // sampleBlock: (qOrigin,rOrigin,S) => { isWaterBuf: Uint8Array, yScaleBuf: Float32Array, N }
-      _blkSample = world.sampleBlock(qOrigin, rOrigin, S);
-      if (_blkSample && _blkSample.isWaterBuf && _blkSample.yScaleBuf) {
+      const blkSample = world.sampleBlock(qOrigin, rOrigin, S);
+      if (blkSample && blkSample.isWaterBuf && blkSample.yScaleBuf) {
         usedBulk = true;
-        const isWaterBuf = _blkSample.isWaterBuf;
-        const yScaleBuf = _blkSample.yScaleBuf;
-        const nBuf = _blkSample.N || N;
+        const isWaterBuf = blkSample.isWaterBuf;
+        const yScaleBuf = blkSample.yScaleBuf;
+        const nBuf = blkSample.N || N;
         // iterate in raster order (r from -S..S, q from -S..S)
         for (let p = 0, bufIdx = 0; p < nBuf * nBuf; p++, bufIdx++) {
           const isWater = !!isWaterBuf[bufIdx];
@@ -118,10 +112,7 @@ export function buildWater(ctx) {
           seabed[idx + 2] = 0;
           seabed[idx + 3] = 255;
           if (isWater) {
-            fillWaterCount += 1;
             waterCount += 1;
-          } else {
-            fillLandCount += 1;
           }
           // compute topY for minTop calculations when a cell exists
           const topY = hexMaxY * ys;
@@ -137,18 +128,6 @@ export function buildWater(ctx) {
     // eslint-disable-next-line no-console
     console.warn('[waterBuilder] bulk sampleBlock failed, falling back to per-cell sampling', e && e.message ? e.message : e);
   }
-  // Diagnostic: report whether bulk path was used and a tiny sample of the returned buffers
-  try {
-    // eslint-disable-next-line no-console
-    console.log(`[waterBuilder] debug: usedBulk=${usedBulk}`);
-    if (usedBulk && _blkSample) {
-      const first = Math.min(64, (_blkSample.N || N) * (_blkSample.N || N));
-      const isSample = Array.prototype.slice.call(_blkSample.isWaterBuf.subarray(0, first));
-      const ySample = Array.prototype.slice.call(_blkSample.yScaleBuf.subarray(0, first));
-      // eslint-disable-next-line no-console
-      console.log('[waterBuilder] sampleBlock first entries:', { first, isSample: isSample.slice(0, 32), ySample: ySample.slice(0, 8) });
-    }
-  } catch (e) { /* ignore diag errors */ }
   if (!usedBulk) {
     // micro-optimizations: cache locals
     const getCell = world.getCell ? world.getCell.bind(world) : (qW, rW) => world.getCell(qW, rW);
@@ -172,10 +151,7 @@ export function buildWater(ctx) {
         seabed[idx + 2] = 0;
         seabed[idx + 3] = 255;
         if (isWater) {
-          fillWaterCount += 1;
           waterCount += 1;
-        } else {
-          fillLandCount += 1;
         }
         // compute topY for minTop calculations when a cell exists
         if (cell) {
@@ -187,9 +163,6 @@ export function buildWater(ctx) {
       }
     }
   }
-  const tFillEnd = perfNow();
-  const fillMs = tFillEnd - tFillStart;
-
   const tex = new THREE.DataTexture(data, N, N, THREE.RGBAFormat);
   tex.needsUpdate = true;
   tex.magFilter = THREE.LinearFilter;
@@ -264,87 +237,19 @@ export function buildWater(ctx) {
   };
 
   // Run DT in-place on the two buffers
-  const tDtStart = perfNow();
   dt(toLand);
-  const tDtLandEnd = perfNow();
   dt(toWater);
-  const tDtWaterEnd = perfNow();
-
-  // Debug: small snapshot of DT outputs to catch unexpected all-zero/INF cases
-  try {
-    const sampleCount = Math.min(12, len);
-    const landSample = Array.prototype.slice.call(toLand.subarray(0, sampleCount));
-    const waterSample = Array.prototype.slice.call(toWater.subarray(0, sampleCount));
-    // eslint-disable-next-line no-console
-    console.log('[waterBuilder] DT samples:', { landSample: landSample.slice(0,8), waterSample: waterSample.slice(0,8) });
-  } catch (e) { /* ignore */ }
 
   // Reuse toWater as the final signed-distance array to avoid an extra allocation
   const sdfArr = toWater;
-  // Compute signed values (land -> -dtLand, water -> +dtWater) and gather min/max
-  let minV = Infinity;
-  let maxV = -Infinity;
-  const tSignStart = perfNow();
+  // Compute signed values (land -> -dtLand, water -> +dtWater)
   for (let p = 0, j = 0; p < len; p++, j += 4) {
-  const isLand = data[j] > 0;
-  // Contract: toLand[p] is distance from this cell to nearest land (0 on land),
-  // toWater[p] is distance from this cell to nearest water (0 on water).
-  // Signed SDF should be negative on land (distance to water) and positive on water (distance to land).
-  const v = isLand ? -toWater[p] : toLand[p];
+    const isLand = data[j] > 0;
+    // Contract: toLand[p] is distance from this cell to nearest land (0 on land),
+    // toWater[p] is distance from this cell to nearest water (0 on water).
+    // Signed SDF should be negative on land (distance to water) and positive on water (distance to land).
+    const v = isLand ? -toWater[p] : toLand[p];
     sdfArr[p] = v;
-    if (v < minV) minV = v;
-    if (v > maxV) maxV = v;
-  }
-  const tSignEnd = perfNow();
-  try {
-    const sFirst = Math.min(12, len);
-    // Small snapshot of signed-distance values
-    const sSample = Array.prototype.slice.call(sdfArr.subarray(0, sFirst));
-    // eslint-disable-next-line no-console
-    console.log('[waterBuilder] signed-distance sample:', sSample.slice(0, 8));
-  } catch (e) { /* ignore */ }
-  try {
-    const debugN = Math.min(12, len);
-    const detail = [];
-    for (let p = 0, j = 0; p < debugN; p++, j += 4) {
-      const mask = [data[j], data[j+1], data[j+2], data[j+3]];
-      const isLand = data[j] > 0;
-      detail.push({ p, mask, isLand, toLand: toLand[p], toWater: toWater[p], sdf: sdfArr[p] });
-    }
-    // eslint-disable-next-line no-console
-    console.log('[waterBuilder] detail sample:', detail);
-  } catch (e) { /* ignore */ }
-  const dtLandMs = tDtLandEnd - tDtStart;
-  const dtWaterMs = tDtWaterEnd - tDtLandEnd;
-  const signMs = tSignEnd - tSignStart;
-
-  // Developer diagnostics: always log sizes and a few stats about the generated SDF
-  try {
-    const tNow =
-      typeof performance !== 'undefined' && performance.now
-        ? performance.now()
-        : Date.now();
-    const buildMs = tNow - startTs;
-    let minV = Infinity;
-    let maxV = -Infinity;
-    for (let i = 0; i < sdfArr.length; i++) {
-      const v = sdfArr[i];
-      if (v < minV) minV = v;
-      if (v > maxV) maxV = v;
-    }
-    // eslint-disable-next-line no-console
-    console.log(
-      `[waterBuilder] debug: S_uncapped=${S_uncapped} S=${S} N=${N} len=${len} buildMs=${buildMs.toFixed(2)}ms min=${minV.toFixed(4)} max=${maxV.toFixed(4)} fill=${fillMs.toFixed(2)}ms fillWater=${fillWaterCount} fillLand=${fillLandCount} dtLand=${dtLandMs.toFixed(2)}ms dtWater=${dtWaterMs.toFixed(2)}ms sign=${signMs.toFixed(2)}ms`
-    );
-    // Also log grid mapping parameters we pass to the material
-    // eslint-disable-next-line no-console
-    console.log(
-      `[waterBuilder] gridParams: gridN=${N} S=${S} q0=${qOrigin} r0=${rOrigin} qMin=${qMin} qMax=${qMax} rMin=${rMin} rMax=${rMax} dQ=${dQ} dR=${dR} padQL=${padQMin} padQR=${padQMax} padRL=${padRMin} padRR=${padRMax} hexW=${hexW_est.toFixed(4)} hexH=${hexH_est.toFixed(4)}`
-    );
-  } catch (e) {
-    // swallow diagnostics errors to avoid breaking production flow
-    // eslint-disable-next-line no-console
-    console.warn('[waterBuilder] debug logging failed', e && e.message ? e.message : e);
   }
   // Crop square textures to the exact rectangular neighborhood to avoid any pad-induced scaling
   const gridW = Math.max(1, N - padQMin - padQMax);


### PR DESCRIPTION
## Summary
- remove debug/timing logging from the waterBuilder helper
- tidy unused counters and helpers after stripping the logs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d402297c688327ac1dcd5c2dbb43d7