### PR TITLE
Align ability module with MVC validation rules

### DIFF
--- a/server/src/modules/ability/ability.controller.ts
+++ b/server/src/modules/ability/ability.controller.ts
@@ -1,10 +1,24 @@
 import { Request, Response } from 'express';
 import { asyncHandler } from '../../utils/asyncHandler';
-import { createAbilityElement, listAbilityElements, getAbilityElement, updateAbilityElement, deleteAbilityElement } from './ability.service';
+import {
+  createAbilityElement,
+  listAbilityElements,
+  getAbilityElement,
+  updateAbilityElement,
+  deleteAbilityElement,
+} from './ability.service';
+import { AbilityElementCreatePayload, AbilityElementUpdatePayload, DomainError } from './ability.domain';
 
 export const postCreate = asyncHandler(async (req: Request, res: Response) => {
-  const created = await createAbilityElement(req.body);
-  res.status(201).json(created);
+  try {
+    const created = await createAbilityElement(req.body as AbilityElementCreatePayload);
+    res.status(201).json(created);
+  } catch (err) {
+    if (err instanceof DomainError) {
+      return res.status(400).json({ error: err.message, code: err.code });
+    }
+    throw err;
+  }
 });
 
 export const getList = asyncHandler(async (_req: Request, res: Response) => {
@@ -21,8 +35,15 @@ export const getOne = asyncHandler(async (req: Request, res: Response) => {
 
 export const putUpdate = asyncHandler(async (req: Request, res: Response) => {
   const id = Number(req.params.id);
-  const updated = await updateAbilityElement(id, req.body);
-  res.json(updated);
+  try {
+    const updated = await updateAbilityElement(id, req.body as AbilityElementUpdatePayload);
+    res.json(updated);
+  } catch (err) {
+    if (err instanceof DomainError) {
+      return res.status(400).json({ error: err.message, code: err.code });
+    }
+    throw err;
+  }
 });
 
 export const delOne = asyncHandler(async (req: Request, res: Response) => {

--- a/server/src/modules/ability/ability.domain.ts
+++ b/server/src/modules/ability/ability.domain.ts
@@ -5,30 +5,94 @@ export class DomainError extends Error {
   }
 }
 
-export type AbilityElementInput = {
-  name?: string | null;
-  icon?: string | null;
-  effect?: string | null;
-  tag?: string | null;
-  damage?: number | null;
-  healing?: number | null;
-  debuff?: number | null;
-  buff?: number | null;
-  color?: string | null;
+export type AbilityElementRecord = {
+  name: string | null;
+  icon: string | null;
+  effect: string | null;
+  tag: string | null;
+  damage: number | null;
+  healing: number | null;
+  debuff: number | null;
+  buff: number | null;
+  color: string | null;
 };
 
-export function normalizeAbilityElementPayload(payload: any): AbilityElementInput {
-  const name = payload?.name == null ? null : String(payload.name).trim();
-  if (name === '') throw new DomainError('NAME_REQUIRED', 'Ability element name cannot be empty');
+export type AbilityElementCreateInput = AbilityElementRecord;
+export type AbilityElementUpdateInput = Partial<AbilityElementRecord>;
+
+export type AbilityElementCreatePayload = Partial<Record<keyof AbilityElementRecord, unknown>> | null | undefined;
+export type AbilityElementUpdatePayload = AbilityElementCreatePayload;
+
+const OPTIONAL_STRING_FIELDS: Array<keyof AbilityElementRecord> = ['icon', 'effect', 'tag', 'color'];
+const OPTIONAL_NUMBER_FIELDS: Array<keyof AbilityElementRecord> = ['damage', 'healing', 'debuff', 'buff'];
+
+function ensureObject(payload: AbilityElementCreatePayload): Record<string, unknown> {
+  if (!payload || typeof payload !== 'object') {
+    throw new DomainError('INVALID_PAYLOAD', 'Ability element payload must be an object');
+  }
+  return payload as Record<string, unknown>;
+}
+
+function normalizeName(value: unknown) {
+  if (value == null) return null;
+  const trimmed = String(value).trim();
+  if (!trimmed) throw new DomainError('NAME_REQUIRED', 'Ability element name cannot be empty');
+  return trimmed;
+}
+
+function normalizeOptionalString(value: unknown) {
+  if (value == null) return null;
+  const trimmed = String(value).trim();
+  return trimmed === '' ? null : trimmed;
+}
+
+function normalizeOptionalNumber(field: string, value: unknown) {
+  if (value == null || value === '') return null;
+  const num = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(num)) {
+    throw new DomainError('INVALID_NUMBER', `${field} must be a finite number`);
+  }
+  return num;
+}
+
+export function normalizeAbilityElementCreatePayload(payload: AbilityElementCreatePayload): AbilityElementCreateInput {
+  const input = ensureObject(payload);
   return {
-    name: name || null,
-    icon: payload?.icon ?? null,
-    effect: payload?.effect ?? null,
-    tag: payload?.tag ?? null,
-    damage: payload?.damage ?? null,
-    healing: payload?.healing ?? null,
-    debuff: payload?.debuff ?? null,
-    buff: payload?.buff ?? null,
-    color: payload?.color ?? null,
+    name: normalizeName(input.name),
+    icon: normalizeOptionalString(input.icon),
+    effect: normalizeOptionalString(input.effect),
+    tag: normalizeOptionalString(input.tag),
+    damage: normalizeOptionalNumber('damage', input.damage),
+    healing: normalizeOptionalNumber('healing', input.healing),
+    debuff: normalizeOptionalNumber('debuff', input.debuff),
+    buff: normalizeOptionalNumber('buff', input.buff),
+    color: normalizeOptionalString(input.color),
   };
+}
+
+export function normalizeAbilityElementUpdatePayload(payload: AbilityElementUpdatePayload): AbilityElementUpdateInput {
+  const input = ensureObject(payload);
+  const normalized: AbilityElementUpdateInput = {};
+
+  if (Object.prototype.hasOwnProperty.call(input, 'name')) {
+    normalized.name = normalizeName(input.name);
+  }
+
+  for (const field of OPTIONAL_STRING_FIELDS) {
+    if (Object.prototype.hasOwnProperty.call(input, field)) {
+      normalized[field] = normalizeOptionalString(input[field]);
+    }
+  }
+
+  for (const field of OPTIONAL_NUMBER_FIELDS) {
+    if (Object.prototype.hasOwnProperty.call(input, field)) {
+      normalized[field] = normalizeOptionalNumber(field, input[field]);
+    }
+  }
+
+  if (Object.keys(normalized).length === 0) {
+    throw new DomainError('NO_UPDATES', 'No updatable fields provided');
+  }
+
+  return normalized;
 }

--- a/server/src/modules/ability/ability.routes.ts
+++ b/server/src/modules/ability/ability.routes.ts
@@ -1,12 +1,14 @@
 import { Router } from 'express';
 import { postCreate, getList, getOne, putUpdate, delOne } from './ability.controller';
+import { validate } from '../../middlewares/validate';
+import { abilityIdRules, createAbilityRules, updateAbilityRules } from './ability.validators';
 
 const router = Router();
 
-router.post('/', postCreate);
+router.post('/', validate(createAbilityRules), postCreate);
 router.get('/', getList);
-router.get('/:id', getOne);
-router.put('/:id', putUpdate);
-router.delete('/:id', delOne);
+router.get('/:id', validate(abilityIdRules), getOne);
+router.put('/:id', validate([...abilityIdRules, ...updateAbilityRules]), putUpdate);
+router.delete('/:id', validate(abilityIdRules), delOne);
 
 export default router;

--- a/server/src/modules/ability/ability.service.ts
+++ b/server/src/modules/ability/ability.service.ts
@@ -1,13 +1,18 @@
 import { prisma } from '../../db/prisma';
-import { normalizeAbilityElementPayload, DomainError } from './ability.domain';
+import {
+  normalizeAbilityElementCreatePayload,
+  normalizeAbilityElementUpdatePayload,
+  DomainError,
+  AbilityElementCreatePayload,
+  AbilityElementUpdatePayload,
+} from './ability.domain';
 
-export async function createAbilityElement(payload: any) {
-  const normalized = normalizeAbilityElementPayload(payload || {});
+export async function createAbilityElement(payload: AbilityElementCreatePayload) {
   try {
-    return prisma.abilityElement.create({ data: normalized as any });
-  } catch (e: any) {
-    // If domain validation threw, map it to a JS Error for callers
-    if (e instanceof DomainError) throw new Error(e.message);
+    const normalized = normalizeAbilityElementCreatePayload(payload);
+    return await prisma.abilityElement.create({ data: normalized });
+  } catch (e) {
+    if (e instanceof DomainError) throw e;
     throw e;
   }
 }
@@ -20,8 +25,14 @@ export async function getAbilityElement(id: number) {
   return prisma.abilityElement.findUnique({ where: { id } });
 }
 
-export async function updateAbilityElement(id: number, data: any) {
-  return prisma.abilityElement.update({ where: { id }, data });
+export async function updateAbilityElement(id: number, data: AbilityElementUpdatePayload) {
+  try {
+    const normalized = normalizeAbilityElementUpdatePayload(data);
+    return await prisma.abilityElement.update({ where: { id }, data: normalized });
+  } catch (e) {
+    if (e instanceof DomainError) throw e;
+    throw e;
+  }
 }
 
 export async function deleteAbilityElement(id: number) {

--- a/server/src/modules/ability/ability.validators.ts
+++ b/server/src/modules/ability/ability.validators.ts
@@ -1,0 +1,62 @@
+import { Rules, Rule } from '../../utils/validators';
+
+const coerceNumber = (value: unknown) => {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed === '') return value;
+    return Number(trimmed);
+  }
+  if (typeof value === 'number') return value;
+  return Number(value);
+};
+
+const numericRule = (key: string): Rule => ({
+  in: 'body',
+  key,
+  optional: true,
+  coerce: coerceNumber,
+  validate: (v) => typeof v === 'number' && Number.isFinite(v),
+  message: `body.${key} must be a finite number`,
+});
+
+const trimmedStringRule = (
+  key: string,
+  { required = false, allowEmpty = false }: { required?: boolean; allowEmpty?: boolean } = {},
+): Rule => ({
+  in: 'body',
+  key,
+  optional: !required,
+  coerce: (v) => {
+    if (v == null) return v as any;
+    if (typeof v === 'string') return v.trim();
+    return String(v).trim();
+  },
+  validate: (v) => typeof v === 'string' && (allowEmpty || v.length > 0),
+  message: allowEmpty ? `body.${key} must be a string` : `body.${key} must be a non-empty string`,
+});
+
+export const abilityIdRules: Rules = [
+  {
+    in: 'params',
+    key: 'id',
+    coerce: (v) => Number(v),
+    validate: (v) => typeof v === 'number' && Number.isInteger(v) && v > 0,
+    message: 'params.id must be a positive integer',
+  },
+];
+
+export const createAbilityRules: Rules = [
+  trimmedStringRule('name'),
+  trimmedStringRule('icon', { allowEmpty: true }),
+  trimmedStringRule('effect', { allowEmpty: true }),
+  trimmedStringRule('tag', { allowEmpty: true }),
+  trimmedStringRule('color', { allowEmpty: true }),
+  numericRule('damage'),
+  numericRule('healing'),
+  numericRule('debuff'),
+  numericRule('buff'),
+];
+
+export const updateAbilityRules: Rules = [
+  ...createAbilityRules,
+];

--- a/server/src/modules/ability/tests/ability.domain.test.ts
+++ b/server/src/modules/ability/tests/ability.domain.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { DomainError, normalizeAbilityElementPayload } from '../ability.domain';
+import {
+  DomainError,
+  normalizeAbilityElementCreatePayload,
+  normalizeAbilityElementUpdatePayload,
+} from '../ability.domain';
 
 describe('ability.domain', () => {
   it('DomainError is instantiable', () => {
@@ -8,7 +12,29 @@ describe('ability.domain', () => {
     expect(e.name).toBe('DomainError');
   });
 
-  it('normalizeAbilityElementPayload rejects empty name', () => {
-    expect(() => normalizeAbilityElementPayload({ name: '' })).toThrow(DomainError);
+  it('normalizeAbilityElementCreatePayload rejects empty name', () => {
+    expect(() => normalizeAbilityElementCreatePayload({ name: '' })).toThrow(DomainError);
+  });
+
+  it('normalizeAbilityElementCreatePayload coerces values', () => {
+    const normalized = normalizeAbilityElementCreatePayload({
+      name: '  Fire  ',
+      damage: '12',
+      healing: null,
+      color: '  #fff  ',
+    });
+    expect(normalized).toMatchObject({ name: 'Fire', damage: 12, healing: null, color: '#fff' });
+  });
+
+  it('normalizeAbilityElementUpdatePayload accepts partial updates', () => {
+    const normalized = normalizeAbilityElementUpdatePayload({
+      damage: '4',
+      name: '  Frost  ',
+    });
+    expect(normalized).toEqual({ damage: 4, name: 'Frost' });
+  });
+
+  it('normalizeAbilityElementUpdatePayload rejects empty patch', () => {
+    expect(() => normalizeAbilityElementUpdatePayload({})).toThrow(DomainError);
   });
 });


### PR DESCRIPTION
## Summary
- add transport-level validation to ability routes and surface domain errors with 400 responses
- expand the ability domain model to normalize create/update payloads and cover them with tests
- route service calls through the new normalization helpers to keep business logic within the service/domain layers

## Testing
- npm test *(fails: suite expects Prisma transaction mocks for equipment tests; see failure output)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d56c0be48327a6ddc872b8ca7419