### PR TITLE
refactor: load socket server via side-effect import

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,6 +1,5 @@
 import app from './app';
-import { createServer } from 'http';
-import createWSServer from './lib/socket';
+import './lib/socket';
 
 const PORT = Number(process.env.PORT ?? 3000);
 


### PR DESCRIPTION
## Summary
- drop the unused HTTP server import in the API entrypoint
- bootstrap the WebSocket server via a side-effect import to keep startup behavior intact

## Testing
- npm run build
- timeout 5s node dist/server.js > server.log 2>&1

------
https://chatgpt.com/codex/tasks/task_e_68d86c3f85f483278bfffbc8478da37c