### PR TITLE
Add ability slot to abilities panel

### DIFF
--- a/client/src/components/abilities/AbilitiesSlots.vue
+++ b/client/src/components/abilities/AbilitiesSlots.vue
@@ -1,12 +1,13 @@
 <template>
   <div class="abilities-root d-flex">
     <SlotCell
-      v-for="s in slots"
+      v-for="s in resolvedSlots"
       :key="s.id"
       :slot-id="s.id"
       type="ability"
       :item="s.item"
       :label="s.label"
+      :source="s.source || null"
       @dropped="onDropped"
       @click="onClick"
     />
@@ -15,16 +16,28 @@
 
 <script setup>
 import SlotCell from "@/components/shared/SlotCell.vue";
-import { reactive } from "vue";
+import { computed } from "vue";
+
+const props = defineProps({
+  slots: {
+    type: Array,
+    default: () => [],
+  },
+});
 
 const emit = defineEmits(["ability-drop", "ability-click"]);
 
-// simple local placeholder for three ability slots; parent can pass real data
-const slots = reactive([
-  { id: "ability1", label: "Ability 1", item: null },
-  { id: "ability2", label: "Ability 2", item: null },
-  { id: "ability3", label: "Ability 3", item: null },
-]);
+const resolvedSlots = computed(() => {
+  if (Array.isArray(props.slots) && props.slots.length > 0) return props.slots;
+  return [
+    {
+      id: "ability",
+      label: "Ability Slot",
+      item: null,
+      source: null,
+    },
+  ];
+});
 
 function onDropped(payload) {
   emit("ability-drop", payload);


### PR DESCRIPTION
## Summary
- allow AbilitiesSlots to render provided slot metadata with a default single ability slot
- show the equipped ability gem in the abilities tab and wire drop handling to the equip API

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d874af46dc83279ba9d47ef6f5602e