### PR TITLE
Move container icon presentation to client

### DIFF
--- a/client/src/components/character/EquipmentSlot.vue
+++ b/client/src/components/character/EquipmentSlot.vue
@@ -170,7 +170,7 @@ async function onSlotDropped({ payload }) {
           updatedContainerIds: res.updatedContainerIds,
         });
         if (Array.isArray(res.nestableContainers))
-          userStore.nestableInventory = res.nestableContainers;
+          userStore.setNestableInventory(res.nestableContainers);
         try {
           console.debug(
             "[EquipmentSlot] post-setCharacterAndInventory inventory",
@@ -250,7 +250,7 @@ async function onSlotDropped({ payload }) {
             updatedContainerIds: res.updatedContainerIds,
           });
           if (Array.isArray(res.nestableContainers))
-            userStore.nestableInventory = res.nestableContainers;
+          userStore.setNestableInventory(res.nestableContainers);
           try {
             console.debug(
               "[EquipmentSlot] post-setCharacterAndInventory inventory",

--- a/client/src/components/inventory/InventoryGrid.vue
+++ b/client/src/components/inventory/InventoryGrid.vue
@@ -73,6 +73,7 @@
 import Slot from "@/components/shared/Slot.vue";
 import { computed, ref, onMounted, onBeforeUnmount } from "vue";
 import dragEventBus from "@/lib/dragEventBus";
+import { iconForContainerType } from "@/utils/containerPresentation";
 // Import the whole mdi namespace and pick the exact exported names that exist
 import * as mdi from "@mdi/js";
 
@@ -167,10 +168,14 @@ const slots = computed(() => {
         itemsByIndex[it.containerIndex] = it;
     });
 
+    const iconName =
+      (c && typeof c.icon === "string" && c.icon) ||
+      iconForContainerType(c?.containerType);
+
     // heuristics to detect backpack-like containers so we can render a larger slot
     const isBackpackContainer = Boolean(
       c &&
-        (c.icon === "backpack" ||
+        (iconName === "backpack" ||
           String(c.containerType || "").toUpperCase() === "BACKPACK" ||
           String(c.name || "")
             .toLowerCase()
@@ -202,7 +207,10 @@ const slots = computed(() => {
         containerId: c.id,
         localIndex: i,
         item: itemsByIndex[i] || null,
-        containerIconSvg: c && c.icon ? iconMap[c.icon] || null : null,
+        containerIconSvg:
+          iconName && Object.prototype.hasOwnProperty.call(iconMap, iconName)
+            ? iconMap[iconName]
+            : null,
         // only treat the first cell as the special pack cell when the container
         // isn't using hiddenFirstCell (we render the visual pack slot separately)
         isPack: isBackpackContainer && !c.hiddenFirstCell && i === 0,

--- a/client/src/components/panels/AbilitiesPanel.vue
+++ b/client/src/components/panels/AbilitiesPanel.vue
@@ -140,7 +140,7 @@ function applyEquipmentResponse(res, fallbackItem) {
       updatedContainerIds: res.updatedContainerIds,
     });
     if (Array.isArray(res.nestableContainers))
-      userStore.nestableInventory = res.nestableContainers;
+      userStore.setNestableInventory(res.nestableContainers);
   } else {
     userStore.setCharacter(updated);
   }

--- a/client/src/components/panels/InventoryPanel.vue
+++ b/client/src/components/panels/InventoryPanel.vue
@@ -118,6 +118,7 @@ import EquipmentSlot from "@/components/character/EquipmentSlot.vue";
 import dragEventBus from "@/lib/dragEventBus";
 import { useUserStore } from "@/stores/userStore";
 import api from "@/utils/api.js";
+import { iconForContainerType } from "@/utils/containerPresentation";
 
 const userStore = useUserStore();
 const { inventory, character } = storeToRefs(userStore);
@@ -137,8 +138,11 @@ const currentDragItem = ref(null);
 
 function isPackContainer(c) {
   if (!c) return false;
+  const icon =
+    (typeof c.icon === "string" && c.icon) ||
+    iconForContainerType(c?.containerType);
   return Boolean(
-    c.icon === "backpack" ||
+    icon === "backpack" ||
       String(c.containerType || "").toUpperCase() === "PACK" ||
       String(c.containerType || "").toUpperCase() === "BACKPACK" ||
       String(c.name || "")
@@ -525,7 +529,7 @@ async function onDropToPack(e) {
       if (res && res.containers) {
         userStore.setInventory(res.containers);
         if (Array.isArray(res.nestableContainers))
-          userStore.nestableInventory = res.nestableContainers;
+          userStore.setNestableInventory(res.nestableContainers);
       } else if (userStore && userStore.ensureInventory) {
         await userStore.ensureInventory(true);
       }
@@ -553,7 +557,7 @@ async function onDropToPack(e) {
       if (res && res.containers) {
         userStore.setInventory(res.containers);
         if (Array.isArray(res.nestableContainers))
-          userStore.nestableInventory = res.nestableContainers;
+          userStore.setNestableInventory(res.nestableContainers);
       }
     } catch (err) {
       console.error("Failed to equip pack", err);
@@ -675,7 +679,7 @@ async function onMoveItem(payload) {
     if (res && res.containers) {
       userStore.setInventory(res.containers);
       if (Array.isArray(res.nestableContainers))
-        userStore.nestableInventory = res.nestableContainers;
+        userStore.setNestableInventory(res.nestableContainers);
     }
     // if server returned authoritative equipment rows, sync the paper-doll
     if (res && res.equipment) {

--- a/client/src/utils/containerPresentation.js
+++ b/client/src/utils/containerPresentation.js
@@ -1,0 +1,43 @@
+const ICON_MAP = {
+  LIQUID: "water",
+  CONSUMABLES: "food-apple",
+  PACK: "backpack",
+  BACKPACK: "backpack",
+  POCKETS: "hand",
+};
+
+export function iconForContainerType(type) {
+  const key = String(type || "BASIC").toUpperCase();
+  return Object.prototype.hasOwnProperty.call(ICON_MAP, key)
+    ? ICON_MAP[key]
+    : null;
+}
+
+export function mapContainersForClient(containers, mapItemForClient) {
+  if (!Array.isArray(containers)) return [];
+  return containers.map((container) =>
+    mapContainerForClient(container, mapItemForClient)
+  );
+}
+
+export function mapContainerForClient(container, mapItemForClient) {
+  if (!container) return null;
+  const items = Array.isArray(container.items)
+    ? container.items.map((it) =>
+        typeof mapItemForClient === "function"
+          ? mapItemForClient(it)
+          : it
+      )
+    : [];
+  items.sort((a, b) => {
+    const ai = Number.isInteger(a && a.containerIndex) ? a.containerIndex : 0;
+    const bi = Number.isInteger(b && b.containerIndex) ? b.containerIndex : 0;
+    return ai - bi;
+  });
+  return {
+    ...container,
+    containerType: container.containerType || "BASIC",
+    icon: iconForContainerType(container.containerType),
+    items,
+  };
+}

--- a/server/src/modules/character/character.domain.ts
+++ b/server/src/modules/character/character.domain.ts
@@ -1,9 +1,4 @@
-export function mapItemForClient(it: any) {
-  if (!it) return null;
-  // TODO(cleanup): inventory.module defines a similar mapper; deduplicate these helpers.
-  const img = it.image || it.img || '/img/debug/placeholder.png';
-  return { ...it, img, label: it.label || it.name || (it.displayName || null) };
-}
+export { mapItemForClient } from '../common/presentation';
 
 export function makePocketsPlaceholder(pockets: any) {
   return { id: null, label: 'Pockets', img: null, isContainer: true, containerId: pockets.id, capacity: pockets.capacity || 0 };

--- a/server/src/modules/character/character.service.ts
+++ b/server/src/modules/character/character.service.ts
@@ -22,24 +22,13 @@ export async function buildCharacterWithEquipment(character: any) {
   return { ...character, equipped };
 }
 
-// Fetch containers for character and map items/icons for client
+// Fetch containers for character and map items for client
 export async function getContainersForCharacter(characterId: number) {
   const containers = await prisma.container.findMany({ where: { characterId }, include: { items: { orderBy: { containerIndex: 'asc' } } } });
   return containers.map((c: any) => ({
     ...c,
     containerType: c.containerType || 'BASIC',
-    // TODO(cleanup): reuse inventory/equipment icon mapping instead of duplicating switch logic here.
-    icon: ((tpe: any) => {
-      const tstr = String(tpe || 'BASIC').toUpperCase();
-      switch (tstr) {
-        case 'LIQUID': return 'water';
-        case 'CONSUMABLES': return 'food-apple';
-        case 'PACK': return 'backpack';
-        case 'POCKETS': return 'hand';
-        default: return null;
-      }
-    })(c.containerType),
-    items: (c.items || []).map((it: any) => ({ ...it, img: it.image || it.img || '/img/debug/placeholder.png', label: it.label || it.name || null })),
+    items: (c.items || []).map(mapItemForClient),
   }));
 }
 

--- a/server/src/modules/character/tests/character.domain.unit.test.ts
+++ b/server/src/modules/character/tests/character.domain.unit.test.ts
@@ -7,11 +7,12 @@ describe('character.domain utilities', () => {
   });
 
   it('mapItemForClient selects image and label properly', () => {
-    const it = { id: 1, name: 'Sword', displayName: 'The Blade', img: null };
+    const it = { id: 1, name: 'Sword', displayName: 'The Blade', img: null, itemType: 7 };
     const mapped = mapItemForClient(it as any);
     expect(mapped).toHaveProperty('img');
     expect(mapped.img).toBe('/img/debug/placeholder.png');
     expect(mapped.label).toBe('Sword');
+    expect(mapped.itemType).toBe('7');
   });
 
   it('makePocketsPlaceholder shapes pockets placeholder', () => {

--- a/server/src/modules/common/presentation.ts
+++ b/server/src/modules/common/presentation.ts
@@ -1,0 +1,9 @@
+const FALLBACK_IMAGE = '/img/debug/placeholder.png';
+
+export function mapItemForClient(it: any) {
+  if (!it) return null;
+  const img = it.image || it.img || FALLBACK_IMAGE;
+  const label = it.label || it.name || it.displayName || null;
+  const itemType = it.itemType != null ? String(it.itemType) : null;
+  return { ...it, img, label, itemType };
+}

--- a/server/src/modules/equipment/equipment.domain.ts
+++ b/server/src/modules/equipment/equipment.domain.ts
@@ -11,24 +11,6 @@ export function ensureItemBelongsToCharacter(item: any, characterId: number) {
 }
 
 /**
- * Map a containerType (stored on the container) to a UI icon key.
- * Why: UI representation is a presentation concern but the mapping
- * is stable domain knowledge used by multiple places; keep it
- * centralized so changes happen in one place.
- */
-export function iconForContainerType(type: any) {
-  const t = String(type || 'BASIC').toUpperCase();
-  // TODO(cleanup): consolidate icon mapping with inventory/character modules.
-  switch (t) {
-    case 'LIQUID': return 'water';
-    case 'CONSUMABLES': return 'food-apple';
-    case 'PACK': return 'backpack';
-    case 'POCKETS': return 'hand';
-    default: return null;
-  }
-}
-
-/**
  * Recursively checks whether containerId is a descendant (nested inside)
  * the item tree under ancestorItemId.
  * Why: This protects from creating cycles (placing a container inside

--- a/server/src/modules/equipment/equipment.service.ts
+++ b/server/src/modules/equipment/equipment.service.ts
@@ -1,6 +1,6 @@
 import { prisma } from '../../db/prisma';
 import { EquipmentSlot } from '@prisma/client';
-import { ensureItemBelongsToCharacter, DomainError, iconForContainerType, containerIsDescendantOfItem, isValidForSlot, swapEquipmentAndContainer } from './equipment.domain';
+import { ensureItemBelongsToCharacter, DomainError, containerIsDescendantOfItem, isValidForSlot, swapEquipmentAndContainer } from './equipment.domain';
 
 export async function equipItemToCharacter(characterId: number, itemId: number, slot: EquipmentSlot) {
   // Use a transaction so we both upsert the equipment and clear any
@@ -157,18 +157,14 @@ export async function performEquipForCharacter(characterId: number, itemId: numb
 
   const { equipment, containers, capacityUpdated, updatedContainerIds } = txResult;
 
-  const annotatedContainers = containers.map((c: any) => {
-    const type = c.containerType ?? 'BASIC';
-    return {
-      ...c,
-      containerType: type,
-      icon: iconForContainerType(type),
-      items: (c.items ?? []).map((it: any) => ({
-        ...it,
-        image: it.image ?? '/img/debug/placeholder.png',
-      })),
-    };
-  });
+  const annotatedContainers = containers.map((c: any) => ({
+    ...c,
+    containerType: c.containerType ?? 'BASIC',
+    items: (c.items ?? []).map((it: any) => ({
+      ...it,
+      image: it.image ?? '/img/debug/placeholder.png',
+    })),
+  }));
 
   // Provide grouped containers for client: equippedContainers (containers that are equipped or pockets)
   // and nestableContainers (containers marked nestable) while keeping `containers` for compatibility.

--- a/server/src/modules/inventory/inventory.controller.ts
+++ b/server/src/modules/inventory/inventory.controller.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import { asyncHandler } from '../../utils/asyncHandler';
-import { fetchContainersWithItems, mapItemForClient, moveItemForCharacter, iconForContainerType, placeItem } from './inventory.service';
+import { fetchContainersWithItems, mapItemForClient, moveItemForCharacter, placeItem } from './inventory.service';
 import { characterService } from '../character/character.service';
 import { prisma } from '../../db/prisma';
 
@@ -11,7 +11,7 @@ export const getInventory = asyncHandler(async (req: express.Request, res: expre
   const character = await characterService.getActiveCharacterForUser(userId);
   if (!character) return res.status(200).json([]);
   const containers = await fetchContainersWithItems(character.id);
-  const out = containers.map((c: any) => ({ id: c.id, name: c.name || null, label: c.label || null, capacity: c.capacity || 0, containerType: c.containerType || 'BASIC', nestable: !!c.nestable, itemId: c.itemId ?? null, icon: iconForContainerType(c.containerType), items: (c.items || []).map(mapItemForClient) }));
+  const out = containers.map((c: any) => ({ id: c.id, name: c.name || null, label: c.label || null, capacity: c.capacity || 0, containerType: c.containerType || 'BASIC', nestable: !!c.nestable, itemId: c.itemId ?? null, items: (c.items || []).map(mapItemForClient) }));
 
   // Determine which containers are equipped for this character so the client
   // can receive an explicit list of equipped containers and nestable
@@ -86,7 +86,6 @@ export const postAction = asyncHandler(async (req: express.Request, res: express
     containerType: c.containerType || 'BASIC',
     nestable: !!c.nestable,
     itemId: c.itemId ?? null,
-    icon: iconForContainerType(c.containerType),
     items: (c.items || []).map(mapItemForClient),
   }));
 

--- a/server/src/modules/inventory/inventory.service.ts
+++ b/server/src/modules/inventory/inventory.service.ts
@@ -1,6 +1,7 @@
 import { prisma } from '../../db/prisma';
 import { validateMovePayload, ensureValidTargetIndex, DomainError } from './inventory.domain';
 import * as equipmentService from '../equipment/equipment.service';
+import { mapItemForClient as baseMapItemForClient } from '../common/presentation';
 
 // Fetch containers and their items, fall back on P2022 schema mismatch
 export async function fetchContainersWithItems(characterId: number) {
@@ -12,24 +13,7 @@ export async function fetchContainersWithItems(characterId: number) {
   }
 }
 
-export function mapItemForClient(it: any) {
-  if (!it) return null;
-  // TODO(cleanup): consolidate with character.module mapItemForClient to avoid diverging payloads.
-  return { ...it, img: it.image || it.img || '/img/debug/placeholder.png', label: it.label || it.name || null, itemType: it.itemType ? String(it.itemType) : null };
-}
-
-export function iconForContainerType(type: any) {
-  const t = String(type || 'BASIC').toUpperCase();
-  // TODO(cleanup): share this mapping with equipment.domain to keep icon logic centralized.
-  switch (t) {
-    case 'LIQUID': return 'water';
-    case 'CONSUMABLES': return 'food-apple';
-    case 'PACK': return 'backpack';
-    case 'POCKETS': return 'hand';
-    case 'BASIC':
-    default: return null;
-  }
-}
+export const mapItemForClient = baseMapItemForClient;
 
 export async function containerIsDescendantOfItem(containerId: number | null, ancestorItemId: number) {
   let curr: number | null = containerId as any;
@@ -109,7 +93,7 @@ export async function moveItemForCharacter(character: any, payload: any) {
   }
 
   const containers = await fetchContainersWithItems(character.id);
-  return containers.map((c: any) => ({ id: c.id, label: c.label || null, capacity: c.capacity || 0, containerType: c.containerType || 'BASIC', icon: iconForContainerType(c.containerType), items: (c.items || []).map(mapItemForClient) }));
+  return containers.map((c: any) => ({ id: c.id, label: c.label || null, capacity: c.capacity || 0, containerType: c.containerType || 'BASIC', items: (c.items || []).map(mapItemForClient) }));
 }
 
 // Place an item to a destination which may be equipment or a container.

--- a/server/src/modules/inventory/tests/inventory.service.unit.test.ts
+++ b/server/src/modules/inventory/tests/inventory.service.unit.test.ts
@@ -19,10 +19,12 @@ describe('inventory.service', () => {
     expect(inventoryService.mapItemForClient(null)).toBeNull();
   });
 
-  it('iconForContainerType recognizes types', () => {
-    expect(inventoryService.iconForContainerType('POCKETS')).toBe('hand');
-    expect(inventoryService.iconForContainerType('LIQUID')).toBe('water');
-    expect(inventoryService.iconForContainerType(null)).toBeNull();
+  it('mapItemForClient normalizes presentation fields', () => {
+    const mapped = inventoryService.mapItemForClient({ id: 3, image: null, label: null, name: null, displayName: 'Fancy Flask', itemType: 42 } as any);
+    expect(mapped).not.toBeNull();
+    expect(mapped?.img).toBe('/img/debug/placeholder.png');
+    expect(mapped?.label).toBe('Fancy Flask');
+    expect(mapped?.itemType).toBe('42');
   });
 
   it('fetchContainersWithItems falls back on P2022 schema mismatch', async () => {


### PR DESCRIPTION
## Summary
- remove container icon mapping from server modules so responses focus on data only
- add a client-side container presentation helper and use it in the user store to normalize containers and icons
- update inventory UI components to compute icons locally and normalize nestable container updates

## Testing
- npm --prefix server test

------
https://chatgpt.com/codex/tasks/task_e_68d98fb7da6c8327a8d080eaedf56ed4