### PR TITLE
Ensure server responses use standardized envelopes and add tests

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -21,6 +21,9 @@
         </v-card-text>
       </v-card>
     </v-dialog>
+
+    <!-- Toast notifications -->
+    <AppToasts />
   </v-app>
 </template>
 
@@ -30,6 +33,7 @@ import { useRoute } from "vue-router";
 import CharacterPanel from "@/components/dialogs/CharacterPanel.vue";
 import Settings from "@/components/dialogs/Settings.vue";
 import MicroMenu from "@/components/overlay/MicroMenu.vue";
+import AppToasts from "@/components/ui/AppToasts.vue";
 import { useDialogsStore } from "@/stores/dialogsStore";
 import { useSocketStore } from "@/stores/socketStore";
 import { useUserStore } from "@/stores/userStore";

--- a/client/src/components/character/EquipmentSlot.vue
+++ b/client/src/components/character/EquipmentSlot.vue
@@ -151,7 +151,8 @@ async function onSlotDropped({ payload }) {
       slot: String(slotId.value).toUpperCase(),
     };
     try {
-      const res = await api.post("/character/equip", body);
+      const response = await api.post("/character/equip", body);
+      const res = (response && response.data) || {};
       // Debug: log response to help diagnose capacity/container updates
       try {
         console.debug(

--- a/client/src/components/panels/InventoryPanel.vue
+++ b/client/src/components/panels/InventoryPanel.vue
@@ -518,7 +518,7 @@ async function onDropToPack(e) {
         console.warn("Optimistic update failed (non-fatal)", err);
       }
 
-      const res = await api.post("/inventory/action", {
+      const response = await api.post("/inventory/action", {
         itemId: payload.item.id,
         destination: {
           type: "container",
@@ -526,6 +526,7 @@ async function onDropToPack(e) {
           index: moved ? moved.containerIndex : null,
         },
       });
+      const res = (response && response.data) || {};
       if (res && res.containers) {
         userStore.setInventory(res.containers);
         if (Array.isArray(res.nestableContainers))
@@ -549,10 +550,11 @@ async function onDropToPack(e) {
 
   if (payload.source === "equip" || payload.source === "container") {
     try {
-      const res = await api.post("/character/equip", {
+      const response = await api.post("/character/equip", {
         slot: "PACK",
         itemId: payload.item.id,
       });
+      const res = (response && response.data) || {};
       if (res && res.character) userStore.setCharacter(res.character);
       if (res && res.containers) {
         userStore.setInventory(res.containers);
@@ -675,7 +677,8 @@ async function onMoveItem(payload) {
         }
       : null;
     const actionPayload = { itemId: postPayload.itemId, destination };
-    const res = await api.post("/inventory/action", actionPayload);
+    const response = await api.post("/inventory/action", actionPayload);
+    const res = (response && response.data) || {};
     if (res && res.containers) {
       userStore.setInventory(res.containers);
       if (Array.isArray(res.nestableContainers))

--- a/client/src/components/ui/AppToasts.vue
+++ b/client/src/components/ui/AppToasts.vue
@@ -1,0 +1,92 @@
+<template>
+  <teleport to="body">
+    <div class="app-toast-container">
+      <transition-group name="app-toast" tag="div">
+        <v-snackbar
+          v-for="toast in toasts"
+          :key="toast.id"
+          :model-value="isVisible(toast.id)"
+          :timeout="toast.timeout"
+          :color="toast.color"
+          variant="elevated"
+          location="bottom"
+          multi-line
+          @update:modelValue="(value) => handleVisibilityChange(toast.id, value)"
+        >
+          <div class="d-flex align-center justify-space-between w-100">
+            <span class="mr-4">{{ toast.message }}</span>
+            <v-btn
+              v-if="toast.dismissible !== false"
+              icon="mdi-close"
+              variant="text"
+              size="small"
+              @click="handleVisibilityChange(toast.id, false)"
+            />
+          </div>
+        </v-snackbar>
+      </transition-group>
+    </div>
+  </teleport>
+</template>
+
+<script setup>
+import { computed, reactive, watch } from "vue";
+import { useToastStore } from "@/stores/toastStore";
+
+const toastStore = useToastStore();
+const toasts = computed(() => toastStore.toasts);
+const visibility = reactive({});
+
+watch(
+  toasts,
+  (current) => {
+    current.forEach((toast) => {
+      if (visibility[toast.id] == null) {
+        visibility[toast.id] = true;
+      }
+    });
+  },
+  { immediate: true }
+);
+
+function isVisible(id) {
+  if (visibility[id] == null) visibility[id] = true;
+  return visibility[id];
+}
+
+function handleVisibilityChange(id, value) {
+  visibility[id] = value;
+  if (value === false) {
+    toastStore.dismiss(id);
+    delete visibility[id];
+  }
+}
+</script>
+
+<style scoped>
+.app-toast-container {
+  position: fixed;
+  bottom: 16px;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: center;
+  pointer-events: none;
+  z-index: 1000;
+}
+
+.app-toast-enter-active,
+.app-toast-leave-active {
+  transition: all 0.2s ease;
+}
+
+.app-toast-enter-from,
+.app-toast-leave-to {
+  opacity: 0;
+  transform: translateY(16px);
+}
+
+.app-toast-container :deep(.v-snackbar) {
+  pointer-events: all;
+}
+</style>

--- a/client/src/stores/abilityStore.js
+++ b/client/src/stores/abilityStore.js
@@ -11,19 +11,19 @@ export const useAbilityStore = defineStore("ability", {
   actions: {
     async getElements() {
       const response = await api.get("ability/elements");
-      this.elements = response;
+      this.elements = response.data ?? response;
     },
     async getShapes() {
       const response = await api.get("ability/shapes");
-      this.shapes = response;
+      this.shapes = response.data ?? response;
     },
     async getTypes() {
       const response = await api.get("ability/types");
-      this.types = response;
+      this.types = response.data ?? response;
     },
     async getRanges() {
       const response = await api.get("ability/ranges");
-      this.ranges = response;
+      this.ranges = response.data ?? response;
     },
     async loadAll() {
       // simple parallel load
@@ -33,10 +33,10 @@ export const useAbilityStore = defineStore("ability", {
         api.get("ability/types"),
         api.get("ability/ranges"),
       ]);
-      this.elements = els;
-      this.shapes = shapes;
-      this.types = types;
-      this.ranges = ranges;
+      this.elements = els.data ?? els;
+      this.shapes = shapes.data ?? shapes;
+      this.types = types.data ?? types;
+      this.ranges = ranges.data ?? ranges;
     },
   },
 });

--- a/client/src/stores/dataStore.js
+++ b/client/src/stores/dataStore.js
@@ -8,7 +8,8 @@ export const useDataStore = defineStore("data", {
   actions: {
     async getRaces() {
       const response = await api.get("data/races");
-      this.races = response.races;
+      const payload = (response && response.data) || {};
+      this.races = payload.races || payload;
     },
   },
 });

--- a/client/src/stores/toastStore.js
+++ b/client/src/stores/toastStore.js
@@ -1,0 +1,40 @@
+import { defineStore } from "pinia";
+
+let nextId = 1;
+
+function normalizeOptions(message, options = {}) {
+  if (!message) {
+    return null;
+  }
+  return {
+    id: nextId++,
+    message: String(message),
+    color: options.color || "error",
+    timeout: typeof options.timeout === "number" ? options.timeout : 6000,
+    dismissible: options.dismissible !== false,
+  };
+}
+
+export const useToastStore = defineStore("toast", {
+  state: () => ({
+    toasts: [],
+  }),
+  actions: {
+    push(message, options = {}) {
+      const toast = normalizeOptions(message, options);
+      if (!toast) return null;
+      this.toasts.push(toast);
+      return toast.id;
+    },
+    showError(message, options = {}) {
+      return this.push(message, { ...options, color: options.color || "error" });
+    },
+    dismiss(id) {
+      if (id == null) return;
+      this.toasts = this.toasts.filter((toast) => toast.id !== id);
+    },
+    clear() {
+      this.toasts = [];
+    },
+  },
+});

--- a/client/src/stores/worldStore.js
+++ b/client/src/stores/worldStore.js
@@ -23,7 +23,8 @@ export const useWorldStore = defineStore("world", {
       try {
         this.lastError = null;
         const res = await api.get("world/seed");
-        this.worldSeed = res?.seed ?? null;
+        const payload = (res && res.data) || {};
+        this.worldSeed = payload?.seed ?? null;
       } catch (e) {
         this.lastError = e?.message || String(e);
         this.worldSeed = null;
@@ -36,8 +37,13 @@ export const useWorldStore = defineStore("world", {
         this.locationsLoading = true;
         this.lastError = null;
         const res = await api.get("world/locations");
-        // Accept either array or { locations: [...] }
-        this.locations = Array.isArray(res) ? res : res?.locations ?? [];
+        const payload = (res && res.data) || {};
+        const list = Array.isArray(payload)
+          ? payload
+          : Array.isArray(payload.locations)
+          ? payload.locations
+          : [];
+        this.locations = list;
       } catch (e) {
         this.lastError = e?.message || String(e);
         this.locations = this.locations ?? [];

--- a/client/src/utils/api.js
+++ b/client/src/utils/api.js
@@ -1,9 +1,89 @@
 import router from "@/router/index.js";
+import { useToastStore } from "@/stores/toastStore";
 
-// Resolve API base endpoint without depending on a global store
-function resolveApiBase() {
+export class ApiError extends Error {
+  constructor(message, options = {}) {
+    super(message || "Request failed");
+    this.name = "ApiError";
+    this.status = options.status ?? null;
+    this.code = options.code ?? null;
+    this.details = options.details ?? null;
+    this.payload = options.payload ?? null;
+  }
+}
+
+let toastStore;
+function getToastStore() {
   try {
-    // Prefer Vite env variable if provided, else default localhost
+    if (!toastStore) toastStore = useToastStore();
+    return toastStore;
+  } catch (err) {
+    return null;
+  }
+}
+
+function showToast(message) {
+  const store = getToastStore();
+  if (store) {
+    store.showError(message);
+  } else {
+    console.error("API error:", message);
+  }
+}
+
+function extractMessage(payload, fallback = "Request failed") {
+  if (!payload && payload !== 0) return fallback;
+  if (typeof payload === "string") {
+    return payload || fallback;
+  }
+  if (typeof payload === "object") {
+    if (payload.error && payload.error.message) return payload.error.message;
+    if (payload.message) return payload.message;
+    if (payload.data && typeof payload.data === "object" && payload.data.message) {
+      return payload.data.message;
+    }
+  }
+  return fallback;
+}
+
+async function parseBody(response) {
+  const contentType = response.headers.get("content-type") || "";
+  if (response.status === 204) return null;
+  const text = await response.text();
+  if (!text) return null;
+  if (contentType.includes("application/json")) {
+    try {
+      return JSON.parse(text);
+    } catch (err) {
+      return null;
+    }
+  }
+  return text;
+}
+
+function handleFailure(status, payload) {
+  const message = extractMessage(payload, status === 401 ? "Please sign in" : "Request failed");
+  if (status === 401 && typeof document !== "undefined") {
+    try {
+      const currentPath = document.location ? document.location.pathname : null;
+      if (currentPath !== "/login") {
+        router.push("/login");
+      }
+    } catch (err) {
+      /* ignore router push failures */
+    }
+  }
+  showToast(message);
+  throw new ApiError(message, {
+    status,
+    code: payload && payload.error ? payload.error.code : null,
+    details: payload && payload.error ? payload.error.details : null,
+    payload,
+  });
+}
+
+const API_BASE = (() => {
+  try {
     const fromEnv =
       import.meta && import.meta.env && import.meta.env.VITE_API_ENDPOINT
         ? import.meta.env.VITE_API_ENDPOINT
@@ -12,58 +92,65 @@ function resolveApiBase() {
   } catch (e) {
     return "http://localhost:3000";
   }
-}
-const API_BASE = resolveApiBase();
-const IS_DEV =
-  typeof window !== "undefined" && window.location && window.location.port;
+})();
+
+const IS_DEV = typeof window !== "undefined" && window.location && window.location.port;
 
 const api = {
-  call: (method, url, input) => {
+  async call(method, url, input) {
     const suffix = String(url || "").replace(/^\//, "");
-    // In dev, prefer the Vite proxy under /api to avoid CORS
     const path = IS_DEV
       ? `/api/${suffix}`
       : `${API_BASE.replace(/\/$/, "")}/${suffix}`;
-    return fetch(path, {
-      method,
 
-      // https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
-      mode: "cors",
-      credentials: "include",
+    try {
+      const response = await fetch(path, {
+        method,
+        mode: "cors",
+        credentials: "include",
+        headers: {
+          "X-Organization-Alias": "web-client",
+          "Cache-Control": "no-cache",
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        body:
+          method === "POST" || method === "PATCH" ? JSON.stringify(input) : null,
+      });
 
-      headers: {
-        "X-Organization-Alias": "web-client",
-        "Cache-Control": "no-cache",
-        Accept: "application/json",
-        "Content-Type": "application/json",
-      },
+      const payload = await parseBody(response);
 
-      body:
-        method === "POST" || method === "PATCH" ? JSON.stringify(input) : null,
-    })
-      .then((response) => {
-        console.log(response);
-        // If there is something wrong
-        if (!response.ok) {
-          switch (response.status) {
-            case 401:
-              if (document.location.pathname !== "/login") {
-                router.push("/login");
-              }
-              break;
-            default:
-            // TODO create error dialog/toast
-          }
-          throw new Error();
+      if (!response.ok) {
+        handleFailure(response.status, payload);
+      }
+
+      if (payload && typeof payload === "object" && "success" in payload) {
+        if (payload.success) {
+          return payload;
         }
-        return response;
-      })
-      .then((response) => response.json());
+        handleFailure(response.status, payload);
+      }
+
+      return { success: true, data: payload, meta: null, message: null };
+    } catch (err) {
+      if (err instanceof ApiError) throw err;
+      const message = err && err.message ? err.message : "Network request failed";
+      showToast(message);
+      throw new ApiError(message, { status: null, details: null, payload: null });
+    }
   },
-  get: (url, input) => api.call("GET", url, input),
-  post: (url, input) => api.call("POST", url, input),
-  patch: (url, input) => api.call("PATCH", url, input),
-  delete: (url, input) => api.call("DELETE", url, input),
+  get(url, input) {
+    return api.call("GET", url, input);
+  },
+  post(url, input) {
+    return api.call("POST", url, input);
+  },
+  patch(url, input) {
+    return api.call("PATCH", url, input);
+  },
+  delete(url, input) {
+    return api.call("DELETE", url, input);
+  },
 };
 
 export default api;

--- a/client/src/views/primary/Builder.vue
+++ b/client/src/views/primary/Builder.vue
@@ -234,17 +234,16 @@ function setAvatar(image_index) {
   currentStage.value = "finish";
 }
 
-function createCharacter() {
+async function createCharacter() {
   const req = { name: name.value, raceId: race_id.value, image: avatar.value };
-  api.post("user/character/create", req).then((response) => {
-    if (response.success) {
+  try {
+    const response = await api.post("user/character/create", req);
+    if (response && response.success) {
       router.push("/characters");
-    } else {
-      console.log("Character creation failed!");
-      console.log(response.status);
-      console.log(typeof response.status);
     }
-  });
+  } catch (err) {
+    console.warn("Character creation failed", err);
+  }
 }
 </script>
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -8,7 +8,7 @@
       "name": "daemios-api",
       "version": "0.0.0",
       "dependencies": {
-        "@prisma/client": "^5.5.2",
+        "@prisma/client": "^6.14.0",
         "@quixo3/prisma-session-store": "^3.1.13",
         "bcrypt": "^5.1.1",
         "cookie-parser": "^1.4.6",
@@ -27,18 +27,35 @@
         "ws": "^8.13.0"
       },
       "devDependencies": {
+        "@types/bcrypt": "^5.0.2",
+        "@types/cors": "^2.8.19",
+        "@types/express": "^4.17.21",
+        "@types/express-session": "^1.18.2",
+        "@types/morgan": "^1.9.10",
+        "@types/node": "^20.5.1",
+        "@types/passport": "^1.0.17",
+        "@types/passport-local": "^1.0.38",
+        "@types/ws": "^8.18.1",
         "eslint-config-airbnb": "^19.0.4",
         "eslint-plugin-import": "^2.29.0",
         "nodemon": "^3.1.0",
-        "prisma": "^5.22.0"
+        "prisma": "^5.22.0",
+        "supertest": "^7.1.1",
+        "ts-node": "^10.9.1",
+        "ts-node-dev": "^2.0.0",
+        "typescript": "^5.6.2"
       }
     },
     "..": {
       "name": "daemios-monorepo",
       "workspaces": [
         "client",
-        "server"
+        "server",
+        "shared"
       ],
+      "dependencies": {
+        "simplex-noise": "^4.0.3"
+      },
       "devDependencies": {
         "concurrently": "^8.2.2"
       }
@@ -83,6 +100,19 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -186,6 +216,34 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@mapbox/node-pre-gyp": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
@@ -263,18 +321,23 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.22.0.tgz",
-      "integrity": "sha512-M0SVXfyHnQREBKxCgyo7sffrKttwE6R8PMq330MIUF0pTwjUhLbW84pFDlf06B27XyCR++VtjugEnIHdr07SVA==",
+      "version": "6.16.2",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.16.2.tgz",
+      "integrity": "sha512-E00PxBcalMfYO/TWnXobBVUai6eW/g5OsifWQsQDzJYm7yaY+IRLo7ZLsaefi0QkTpxfuhFcQ/w180i6kX3iJw==",
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=16.13"
+        "node": ">=18.18"
       },
       "peerDependencies": {
-        "prisma": "*"
+        "prisma": "*",
+        "typescript": ">=5.1.0"
       },
       "peerDependenciesMeta": {
         "prisma": {
+          "optional": true
+        },
+        "typescript": {
           "optional": true
         }
       }
@@ -347,11 +410,244 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/bcrypt": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-5.0.2.tgz",
+      "integrity": "sha512-6atioO8Y75fNcbmj0G7UjI9lXN2pQ/IGJ2FWT4a/btd0Lk9lQalHLKhkgKVZ3r+spnmWUKfbMi1GEe9wyHQfNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.23.tgz",
+      "integrity": "sha512-Crp6WY9aTYP3qPi2wGDo9iUe/rceX01UMhnF1jmwDcKCFM6cx7YhGP/Mpr3y9AASpfHixIG0E6azCcL5OcDHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.6",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
+      "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/express-session": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/@types/express-session/-/express-session-1.18.2.tgz",
+      "integrity": "sha512-k+I0BxwVXsnEU2hV77cCobC08kIsn4y44C3gC0b46uxZVMaXA04lSPgRLR/bSL2w0t0ShJiG8o4jPzRG/nscFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/morgan": {
+      "version": "1.9.10",
+      "resolved": "https://registry.npmjs.org/@types/morgan/-/morgan-1.9.10.tgz",
+      "integrity": "sha512-sS4A1zheMvsADRVfT0lYbJ4S9lmsey8Zo2F7cnbYjWHP67Q0AwMYuuzLlkIM2N8gAbb9cubhIVFwcIN2XyYCkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.17.tgz",
+      "integrity": "sha512-gfehUI8N1z92kygssiuWvLiwcbOB3IRktR6hTDgJlXMYh5OvkPSRmgfoBUmfZt+vhwJtX7v1Yw4KvvAf7c5QKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/passport": {
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.17.tgz",
+      "integrity": "sha512-aciLyx+wDwT2t2/kJGJR2AEeBz0nJU4WuRX04Wu9Dqc5lSUtwu0WERPHYsLhF9PtseiAMPBGNUOtFjxZ56prsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
+    "node_modules/@types/passport-local": {
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/@types/passport-local/-/passport-local-1.0.38.tgz",
+      "integrity": "sha512-nsrW4A963lYE7lNTv9cr5WmiUD1ibYJvWrpE13oxApFsRt77b0RdtZvKbCdNIY4v/QZ6TRQWaDDEwV1kCTmcXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/passport": "*",
+        "@types/passport-strategy": "*"
+      }
+    },
+    "node_modules/@types/passport-strategy": {
+      "version": "0.2.38",
+      "resolved": "https://registry.npmjs.org/@types/passport-strategy/-/passport-strategy-0.2.38.tgz",
+      "integrity": "sha512-GC6eMqqojOooq993Tmnmp7AUTbbQSgilyvpCYQjT+H6JfG/g6RGc7nXEniZlp0zyKJ0WUdOiZWLBZft9Yug1uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/passport": "*"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.5.tgz",
+      "integrity": "sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.8",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.8.tgz",
+      "integrity": "sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-xevGOReSYGM7g/kUBZzPqCrR/KYAo+F0yiPc85WFTJa0MSLtyFTVTU6cJu/aV4mid7IffDIWqo69THF2o4JiEQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/strip-json-comments": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
+      "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
@@ -382,7 +678,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -398,6 +693,19 @@
       "peer": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/agent-base": {
@@ -482,6 +790,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -685,6 +1000,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -833,6 +1155,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -994,6 +1323,29 @@
         "color-support": "bin.js"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1071,6 +1423,13 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
@@ -1082,6 +1441,13 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -1217,6 +1583,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
@@ -1245,6 +1621,27 @@
       "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/doctrine": {
@@ -1287,6 +1684,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/dynamic-dedupe": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/dynamic-dedupe/-/dynamic-dedupe-0.3.0.tgz",
+      "integrity": "sha512-ssuANeD+z97meYOqd50e04Ze5qp4bPqo8cCkI4TRjZkzAUgIDTrXV1R8QCdINpiI+hw14+rYazvTRdQrz0/rFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
       }
     },
     "node_modules/ee-first": {
@@ -2061,6 +2468,13 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -2178,6 +2592,41 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -3284,6 +3733,13 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -4620,6 +5076,27 @@
         "node": ">=10"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -4810,6 +5287,54 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/superagent": {
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.2.3.tgz",
+      "integrity": "sha512-y/hkYGeXAj7wUMjxRbB21g/l6aAEituGXM9Rwl4o20+SX3e8YOSV6BxFXl+dL3Uk0mjSL3kCbNkwURm8/gEDig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.4",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.2"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.1.4.tgz",
+      "integrity": "sha512-tjLPs7dVyqgItVFirHYqe2T+MfWc2VOBQ8QFKKbWTA3PU7liZR8zoSpAi/C1k1ilm9RsXIKYf197oap9wXGVYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^10.2.3"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -4896,12 +5421,128 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
     "node_modules/ts-dedent": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
       "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
       "engines": {
         "node": ">=6.10"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node-dev": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-2.0.0.tgz",
+      "integrity": "sha512-ywMrhCfH6M75yftYvrvNarLEY+SUXtUvU8/0Z6llrHQVBx12GiFk5sStF8UdfE/yfzk9IAq7O5EEbTQsxlBI8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.1",
+        "dynamic-dedupe": "^0.3.0",
+        "minimist": "^1.2.6",
+        "mkdirp": "^1.0.4",
+        "resolve": "^1.0.0",
+        "rimraf": "^2.6.1",
+        "source-map-support": "^0.5.12",
+        "tree-kill": "^1.2.2",
+        "ts-node": "^10.4.0",
+        "tsconfig": "^7.0.0"
+      },
+      "bin": {
+        "ts-node-dev": "lib/bin.js",
+        "tsnd": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "*",
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node-dev/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/tsconfig": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
+      "integrity": "sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/strip-bom": "^3.0.0",
+        "@types/strip-json-comments": "0.0.30",
+        "strip-bom": "^3.0.0",
+        "strip-json-comments": "^2.0.0"
       }
     },
     "node_modules/tsconfig-paths": {
@@ -4914,6 +5555,16 @@
         "json5": "^1.0.2",
         "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tsconfig/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/type-check": {
@@ -5026,6 +5677,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/uid-safe": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
@@ -5061,6 +5726,13 @@
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true
     },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -5091,6 +5763,13 @@
       "engines": {
         "node": ">= 0.4.0"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -5280,10 +5959,30 @@
         }
       }
     },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
@@ -5325,6 +6024,15 @@
       "requires": {
         "@babel/helper-string-parser": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.27.1"
+      }
+    },
+    "@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "0.3.9"
       }
     },
     "@eslint-community/eslint-utils": {
@@ -5395,6 +6103,28 @@
       "dev": true,
       "peer": true
     },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "@mapbox/node-pre-gyp": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
@@ -5454,9 +6184,9 @@
       }
     },
     "@prisma/client": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.22.0.tgz",
-      "integrity": "sha512-M0SVXfyHnQREBKxCgyo7sffrKttwE6R8PMq330MIUF0pTwjUhLbW84pFDlf06B27XyCR++VtjugEnIHdr07SVA==",
+      "version": "6.16.2",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.16.2.tgz",
+      "integrity": "sha512-E00PxBcalMfYO/TWnXobBVUai6eW/g5OsifWQsQDzJYm7yaY+IRLo7ZLsaefi0QkTpxfuhFcQ/w180i6kX3iJw==",
       "requires": {}
     },
     "@prisma/debug": {
@@ -5519,11 +6249,219 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true
     },
+    "@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true
+    },
+    "@types/bcrypt": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-5.0.2.tgz",
+      "integrity": "sha512-6atioO8Y75fNcbmj0G7UjI9lXN2pQ/IGJ2FWT4a/btd0Lk9lQalHLKhkgKVZ3r+spnmWUKfbMi1GEe9wyHQfNQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "requires": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/express": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.23.tgz",
+      "integrity": "sha512-Crp6WY9aTYP3qPi2wGDo9iUe/rceX01UMhnF1jmwDcKCFM6cx7YhGP/Mpr3y9AASpfHixIG0E6azCcL5OcDHsQ==",
+      "dev": true,
+      "requires": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.19.6",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
+      "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "@types/express-session": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/@types/express-session/-/express-session-1.18.2.tgz",
+      "integrity": "sha512-k+I0BxwVXsnEU2hV77cCobC08kIsn4y44C3gC0b46uxZVMaXA04lSPgRLR/bSL2w0t0ShJiG8o4jPzRG/nscFg==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*"
+      }
+    },
+    "@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true
+    },
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true
+    },
+    "@types/morgan": {
+      "version": "1.9.10",
+      "resolved": "https://registry.npmjs.org/@types/morgan/-/morgan-1.9.10.tgz",
+      "integrity": "sha512-sS4A1zheMvsADRVfT0lYbJ4S9lmsey8Zo2F7cnbYjWHP67Q0AwMYuuzLlkIM2N8gAbb9cubhIVFwcIN2XyYCkA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/node": {
+      "version": "20.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.17.tgz",
+      "integrity": "sha512-gfehUI8N1z92kygssiuWvLiwcbOB3IRktR6hTDgJlXMYh5OvkPSRmgfoBUmfZt+vhwJtX7v1Yw4KvvAf7c5QKQ==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "@types/passport": {
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.17.tgz",
+      "integrity": "sha512-aciLyx+wDwT2t2/kJGJR2AEeBz0nJU4WuRX04Wu9Dqc5lSUtwu0WERPHYsLhF9PtseiAMPBGNUOtFjxZ56prsg==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*"
+      }
+    },
+    "@types/passport-local": {
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/@types/passport-local/-/passport-local-1.0.38.tgz",
+      "integrity": "sha512-nsrW4A963lYE7lNTv9cr5WmiUD1ibYJvWrpE13oxApFsRt77b0RdtZvKbCdNIY4v/QZ6TRQWaDDEwV1kCTmcXg==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*",
+        "@types/passport": "*",
+        "@types/passport-strategy": "*"
+      }
+    },
+    "@types/passport-strategy": {
+      "version": "0.2.38",
+      "resolved": "https://registry.npmjs.org/@types/passport-strategy/-/passport-strategy-0.2.38.tgz",
+      "integrity": "sha512-GC6eMqqojOooq993Tmnmp7AUTbbQSgilyvpCYQjT+H6JfG/g6RGc7nXEniZlp0zyKJ0WUdOiZWLBZft9Yug1uA==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*",
+        "@types/passport": "*"
+      }
+    },
+    "@types/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+      "dev": true
+    },
+    "@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true
+    },
+    "@types/send": {
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.5.tgz",
+      "integrity": "sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==",
+      "dev": true,
+      "requires": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "@types/serve-static": {
+      "version": "1.15.8",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.8.tgz",
+      "integrity": "sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg==",
+      "dev": true,
+      "requires": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "*"
+      }
+    },
+    "@types/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-xevGOReSYGM7g/kUBZzPqCrR/KYAo+F0yiPc85WFTJa0MSLtyFTVTU6cJu/aV4mid7IffDIWqo69THF2o4JiEQ==",
+      "dev": true
+    },
+    "@types/strip-json-comments": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
+      "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
+      "dev": true
+    },
+    "@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@ungap/structured-clone": {
       "version": "1.3.0",
@@ -5550,8 +6488,7 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -5560,6 +6497,15 @@
       "dev": true,
       "peer": true,
       "requires": {}
+    },
+    "acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.11.0"
+      }
     },
     "agent-base": {
       "version": "6.0.2",
@@ -5620,6 +6566,12 @@
         "delegates": "^1.0.0",
         "readable-stream": "^3.6.0"
       }
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "argparse": {
       "version": "2.0.1",
@@ -5772,6 +6724,12 @@
       "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
       "dev": true
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
+    },
     "available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -5890,6 +6848,12 @@
         "fill-range": "^7.1.1"
       }
     },
+    "buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
+    },
     "bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -6005,6 +6969,21 @@
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6067,6 +7046,12 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
+    "cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true
+    },
     "cors": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
@@ -6075,6 +7060,12 @@
         "object-assign": "^4",
         "vary": "^1"
       }
+    },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
     },
     "cross-spawn": {
       "version": "7.0.6",
@@ -6091,7 +7082,8 @@
     "daemios-monorepo": {
       "version": "file:..",
       "requires": {
-        "concurrently": "^8.2.2"
+        "concurrently": "^8.2.2",
+        "simplex-noise": "^4.0.3"
       }
     },
     "damerau-levenshtein": {
@@ -6171,6 +7163,12 @@
         "object-keys": "^1.1.1"
       }
     },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true
+    },
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
@@ -6190,6 +7188,22 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
       "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA=="
+    },
+    "dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "requires": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
     },
     "doctrine": {
       "version": "3.0.0",
@@ -6219,6 +7233,15 @@
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
         "gopd": "^1.2.0"
+      }
+    },
+    "dynamic-dedupe": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/dynamic-dedupe/-/dynamic-dedupe-0.3.0.tgz",
+      "integrity": "sha512-ssuANeD+z97meYOqd50e04Ze5qp4bPqo8cCkI4TRjZkzAUgIDTrXV1R8QCdINpiI+hw14+rYazvTRdQrz0/rFQ==",
+      "dev": true,
+      "requires": {
+        "xtend": "^4.0.0"
       }
     },
     "ee-first": {
@@ -6840,6 +7863,12 @@
       "dev": true,
       "peer": true
     },
+    "fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true
+    },
     "fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -6935,6 +7964,30 @@
       "dev": true,
       "requires": {
         "is-callable": "^1.2.7"
+      }
+    },
+    "form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "requires": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
       }
     },
     "forwarded": {
@@ -7712,6 +8765,12 @@
           "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
         }
       }
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "math-intrinsics": {
       "version": "1.1.0",
@@ -8676,6 +9735,22 @@
         "semver": "^7.5.3"
       }
     },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
     "statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -8820,6 +9895,41 @@
       "dev": true,
       "peer": true
     },
+    "superagent": {
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.2.3.tgz",
+      "integrity": "sha512-y/hkYGeXAj7wUMjxRbB21g/l6aAEituGXM9Rwl4o20+SX3e8YOSV6BxFXl+dL3Uk0mjSL3kCbNkwURm8/gEDig==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.4",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.2"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+          "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+          "dev": true
+        }
+      }
+    },
+    "supertest": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.1.4.tgz",
+      "integrity": "sha512-tjLPs7dVyqgItVFirHYqe2T+MfWc2VOBQ8QFKKbWTA3PU7liZR8zoSpAi/C1k1ilm9RsXIKYf197oap9wXGVYg==",
+      "dev": true,
+      "requires": {
+        "methods": "^1.1.2",
+        "superagent": "^10.2.3"
+      }
+    },
     "supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -8885,10 +9995,86 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
+    "tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true
+    },
     "ts-dedent": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
       "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ=="
+    },
+    "ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      }
+    },
+    "ts-node-dev": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-2.0.0.tgz",
+      "integrity": "sha512-ywMrhCfH6M75yftYvrvNarLEY+SUXtUvU8/0Z6llrHQVBx12GiFk5sStF8UdfE/yfzk9IAq7O5EEbTQsxlBI8w==",
+      "dev": true,
+      "requires": {
+        "chokidar": "^3.5.1",
+        "dynamic-dedupe": "^0.3.0",
+        "minimist": "^1.2.6",
+        "mkdirp": "^1.0.4",
+        "resolve": "^1.0.0",
+        "rimraf": "^2.6.1",
+        "source-map-support": "^0.5.12",
+        "tree-kill": "^1.2.2",
+        "ts-node": "^10.4.0",
+        "tsconfig": "^7.0.0"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
+    "tsconfig": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
+      "integrity": "sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==",
+      "dev": true,
+      "requires": {
+        "@types/strip-bom": "^3.0.0",
+        "@types/strip-json-comments": "0.0.30",
+        "strip-bom": "^3.0.0",
+        "strip-json-comments": "^2.0.0"
+      },
+      "dependencies": {
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+          "dev": true
+        }
+      }
     },
     "tsconfig-paths": {
       "version": "3.15.0",
@@ -8979,6 +10165,12 @@
         "reflect.getprototypeof": "^1.0.6"
       }
     },
+    "typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "devOptional": true
+    },
     "uid-safe": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
@@ -9005,6 +10197,12 @@
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true
     },
+    "undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true
+    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -9029,6 +10227,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
+    },
+    "v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
     },
     "vary": {
       "version": "1.1.2",
@@ -9162,10 +10366,22 @@
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "requires": {}
     },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true
+    },
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/server/package.json
+++ b/server/package.json
@@ -43,6 +43,7 @@
     "eslint-config-airbnb": "^19.0.4",
     "eslint-plugin-import": "^2.29.0",
     "nodemon": "^3.1.0",
+    "supertest": "^7.1.1",
     "prisma": "^5.22.0",
     "ts-node": "^10.9.1",
     "ts-node-dev": "^2.0.0",

--- a/server/src/app.test.ts
+++ b/server/src/app.test.ts
@@ -1,0 +1,55 @@
+import request from 'supertest';
+import session from 'express-session';
+import type { NextFunction, Request, Response } from 'express';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./middlewares/user', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./middlewares/user')>();
+  return {
+    ...actual,
+    isAuth: (_req: Request, _res: Response, next: NextFunction) => next(),
+  };
+});
+
+vi.mock('@quixo3/prisma-session-store', () => {
+  const MemoryStore = session.MemoryStore;
+  return {
+    PrismaSessionStore: class extends MemoryStore {
+      constructor(...args: any[]) {
+        super(...args);
+      }
+    },
+  };
+});
+
+import app from './app';
+
+describe('app standardized responses', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns a success envelope for the health check', async () => {
+    const response = await request(app).get('/_health');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      success: true,
+      data: { ok: true },
+      message: 'Healthy',
+    });
+  });
+
+  it('returns standardized error envelope for unknown routes', async () => {
+    const response = await request(app).get('/does-not-exist');
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({
+      success: false,
+      error: {
+        code: 'not_found',
+        message: 'Route not found: GET /does-not-exist',
+      },
+    });
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -15,6 +15,8 @@ import { arenaRouter } from './modules/arena';
 import { worldRouter } from './modules/world';
 import { dmRouter } from './modules/dm';
 import { equipmentRouter } from './modules/equipment';
+import { respondError, respondSuccess } from './utils/apiResponse';
+import { errorMiddleware } from './middlewares/error';
 
 import initializePassport from './passport-config';
 import { isAuth } from './middlewares/user';
@@ -50,6 +52,8 @@ app.use(passport.initialize());
 app.use(passport.session());
 initializePassport(passport);
 
+app.get('/_health', (_req, res) => respondSuccess(res, 200, { ok: true }, 'Healthy'));
+
 app.use('/open', openRouter);
 app.use(isAuth);
 
@@ -62,7 +66,8 @@ app.use('/world', worldRouter);
 app.use('/dm', dmRouter);
 app.use('/character', equipmentRouter);
 
-app.get('/_health', (_req, res) => res.json({ ok: true }));
+app.use((req, res) => respondError(res, 404, 'not_found', `Route not found: ${req.method} ${req.path}`));
+app.use(errorMiddleware);
 
 export default app;
 

--- a/server/src/middlewares/error.test.ts
+++ b/server/src/middlewares/error.test.ts
@@ -1,0 +1,73 @@
+import { Prisma } from '@prisma/client';
+import type { Response } from 'express';
+import { describe, expect, it, vi } from 'vitest';
+
+import { errorMiddleware } from './error';
+import { HttpError } from '../utils/httpError';
+
+type MockResponse = Pick<Response, 'status' | 'json'> & {
+  status: ReturnType<typeof vi.fn>;
+  json: ReturnType<typeof vi.fn>;
+};
+
+const createMockResponse = (): MockResponse => {
+  const res: Partial<Response> = {};
+  res.status = vi.fn().mockReturnThis();
+  res.json = vi.fn().mockReturnThis();
+  return res as MockResponse;
+};
+
+describe('errorMiddleware', () => {
+  it('formats HttpError instances into standardized responses', () => {
+    const res = createMockResponse();
+
+    errorMiddleware(new HttpError(418, 'Short and stout'), {} as any, res as Response, vi.fn());
+
+    expect(res.status).toHaveBeenCalledWith(418);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      error: {
+        code: 'http_error',
+        message: 'Short and stout',
+      },
+    });
+  });
+
+  it('maps Prisma unique constraint errors to conflict responses', () => {
+    const res = createMockResponse();
+    const prismaError = new Prisma.PrismaClientKnownRequestError('Unique constraint', {
+      code: 'P2002',
+      clientVersion: '5.0.0',
+    });
+
+    errorMiddleware(prismaError, {} as any, res as Response, vi.fn());
+
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      error: {
+        code: 'unique_constraint_failed',
+        message: 'Unique constraint failed',
+      },
+    });
+  });
+
+  it('falls back to internal error envelope for unexpected errors', () => {
+    const res = createMockResponse();
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    errorMiddleware(new Error('boom'), {} as any, res as Response, vi.fn());
+
+    expect(consoleSpy).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      error: {
+        code: 'internal_error',
+        message: 'Internal server error',
+      },
+    });
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/server/src/middlewares/error.ts
+++ b/server/src/middlewares/error.ts
@@ -1,15 +1,18 @@
 import { NextFunction, Request, Response } from 'express';
-import { HttpError } from '../utils/httpError';
 import { Prisma } from '@prisma/client';
+import { HttpError } from '../utils/httpError';
+import { respondError } from '../utils/apiResponse';
 
 export function errorMiddleware(err: unknown, _req: Request, res: Response, _next: NextFunction) {
   if (err instanceof Prisma.PrismaClientKnownRequestError) {
-    if (err.code === 'P2002') return res.status(409).json({ error: 'Unique constraint failed' });
-    return res.status(400).json({ error: 'Database error' });
+    if (err.code === 'P2002') {
+      return respondError(res, 409, 'unique_constraint_failed', 'Unique constraint failed');
+    }
+    return respondError(res, 400, 'database_error', 'Database error');
   }
   if (err instanceof HttpError) {
-    return res.status(err.status).json({ error: err.message });
+    return respondError(res, err.status, 'http_error', err.message);
   }
   console.error(err);
-  return res.status(500).json({ error: 'Internal server error' });
+  return respondError(res, 500, 'internal_error', 'Internal server error');
 }

--- a/server/src/middlewares/user.test.ts
+++ b/server/src/middlewares/user.test.ts
@@ -1,0 +1,44 @@
+import express from 'express';
+import request from 'supertest';
+import { describe, expect, it } from 'vitest';
+
+import { isAuth } from './user';
+
+describe('isAuth middleware', () => {
+  it('denies unauthenticated requests with standardized envelope', async () => {
+    const app = express();
+    app.get('/protected', (req, res, next) => {
+      Object.assign(req, {
+        isAuthenticated: () => false,
+      });
+      next();
+    }, isAuth);
+
+    const response = await request(app).get('/protected');
+
+    expect(response.status).toBe(401);
+    expect(response.body).toEqual({
+      success: false,
+      error: {
+        code: 'unauthorized',
+        message: 'You are not authorized to view this resource',
+      },
+    });
+  });
+
+  it('allows authenticated requests to proceed', async () => {
+    const app = express();
+    app.get('/protected', (req, res, next) => {
+      Object.assign(req, {
+        isAuthenticated: () => true,
+      });
+      next();
+    }, isAuth, (_req, res) => {
+      res.status(204).end();
+    });
+
+    const response = await request(app).get('/protected');
+
+    expect(response.status).toBe(204);
+  });
+});

--- a/server/src/middlewares/user.ts
+++ b/server/src/middlewares/user.ts
@@ -1,20 +1,21 @@
 import { Request, Response, NextFunction } from 'express';
 import { validateRegistration } from '../modules/user/user.service';
+import { respondError } from '../utils/apiResponse';
 
 export const registrationValidator = async (req: Request, res: Response, next: NextFunction) => {
   const validationError = validateRegistration(req.body as any);
   if (validationError) {
-    return res.status(400).json({ error: validationError });
+    return respondError(res, 400, 'invalid_payload', validationError);
   }
   next();
 };
 
 export const isAuth = (req: Request, res: Response, next: NextFunction) => {
   if (req.isAuthenticated && req.isAuthenticated()) return next();
-  res.status(401).json({ msg: 'You are not authorized to view this resource' });
+  respondError(res, 401, 'unauthorized', 'You are not authorized to view this resource');
 };
 
 export const isAdmin = (req: Request, res: Response, next: NextFunction) => {
   if (req.user && (req.user as any).admin) return next();
-  res.status(401).json({ msg: 'You are not authorized to view this resource' });
+  respondError(res, 401, 'unauthorized', 'You are not authorized to view this resource');
 };

--- a/server/src/modules/ability/ability.controller.ts
+++ b/server/src/modules/ability/ability.controller.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express';
 import { asyncHandler } from '../../utils/asyncHandler';
+import { respondError, respondSuccess } from '../../utils/apiResponse';
 import {
   createAbilityElement,
   listAbilityElements,
@@ -15,10 +16,10 @@ import { AbilityElementCreatePayload, AbilityElementUpdatePayload, DomainError }
 export const postCreate = asyncHandler(async (req: Request, res: Response) => {
   try {
     const created = await createAbilityElement(req.body as AbilityElementCreatePayload);
-    res.status(201).json(created);
+    respondSuccess(res, 201, created, 'Ability element created');
   } catch (err) {
     if (err instanceof DomainError) {
-      return res.status(400).json({ error: err.message, code: err.code });
+      return respondError(res, 400, err.code, err.message);
     }
     throw err;
   }
@@ -26,39 +27,39 @@ export const postCreate = asyncHandler(async (req: Request, res: Response) => {
 
 export const getList = asyncHandler(async (_req: Request, res: Response) => {
   const list = await listAbilityElements();
-  res.json(list);
+  respondSuccess(res, 200, list);
 });
 
 export const getShapes = asyncHandler(async (_req: Request, res: Response) => {
   const list = await listAbilityShapes();
-  res.json(list);
+  respondSuccess(res, 200, list);
 });
 
 export const getRanges = asyncHandler(async (_req: Request, res: Response) => {
   const list = await listAbilityRanges();
-  res.json(list);
+  respondSuccess(res, 200, list);
 });
 
 export const getTypes = asyncHandler(async (_req: Request, res: Response) => {
   const list = await listAbilityTypes();
-  res.json(list);
+  respondSuccess(res, 200, list);
 });
 
 export const getOne = asyncHandler(async (req: Request, res: Response) => {
   const id = Number(req.params.id);
   const one = await getAbilityElement(id);
-  if (!one) return res.status(404).json({});
-  res.json(one);
+  if (!one) return respondError(res, 404, 'not_found', 'Ability element not found');
+  respondSuccess(res, 200, one);
 });
 
 export const putUpdate = asyncHandler(async (req: Request, res: Response) => {
   const id = Number(req.params.id);
   try {
     const updated = await updateAbilityElement(id, req.body as AbilityElementUpdatePayload);
-    res.json(updated);
+    respondSuccess(res, 200, updated, 'Ability element updated');
   } catch (err) {
     if (err instanceof DomainError) {
-      return res.status(400).json({ error: err.message, code: err.code });
+      return respondError(res, 400, err.code, err.message);
     }
     throw err;
   }
@@ -67,5 +68,5 @@ export const putUpdate = asyncHandler(async (req: Request, res: Response) => {
 export const delOne = asyncHandler(async (req: Request, res: Response) => {
   const id = Number(req.params.id);
   const removed = await deleteAbilityElement(id);
-  res.json(removed);
+  respondSuccess(res, 200, removed, 'Ability element removed');
 });

--- a/server/src/modules/arena/arena.controller.ts
+++ b/server/src/modules/arena/arena.controller.ts
@@ -1,42 +1,55 @@
 import { Request, Response } from 'express';
 import * as service from './arena.service';
+import { respondError, respondSuccess } from '../../utils/apiResponse';
 
 export async function list(req: Request, res: Response) {
   const arenas = await service.listArenaHistories();
   const active = await service.getActiveArenaHistory();
-  res.send({ active_arena_history_id: active ? active.arena_history_id : null, saved_arenas: arenas });
+  respondSuccess(res, 200, {
+    active_arena_history_id: active ? active.arena_history_id : null,
+    saved_arenas: arenas,
+  });
 }
 
 export async function single(req: Request, res: Response) {
   const rows = await service.findArenaHistoryById(req.params.id);
-  res.send(rows);
+  respondSuccess(res, 200, rows);
 }
 
 export async function remove(req: Request, res: Response) {
-  if (!req.params.id) return res.status(400).send('Missing args for arena/delete');
+  if (!req.params.id) {
+    return respondError(res, 400, 'invalid_payload', 'Missing args for arena/delete');
+  }
   await service.deleteArenaHistoryById(req.params.id);
   const rows = await service.listArenaHistories();
-  res.send(rows);
+  respondSuccess(res, 200, rows, 'Arena removed');
 }
 
 export async function load(req: Request, res: Response) {
   const rows = await service.findArenaHistoryById(req.params.id);
-  if (!rows || rows.length === 0) return res.status(404).send('Not found');
+  if (!rows || rows.length === 0) {
+    return respondError(res, 404, 'not_found', 'Arena history not found');
+  }
   await service.updateArenaLastActive(rows[0].arena_history_id);
   const arenas = await service.listArenaHistories();
   const active = await service.getActiveArenaHistory();
   // clear any cached terrain on the app locals if present
   if (req.app && req.app.locals && req.app.locals.arena) req.app.locals.arena.terrain = null;
-  res.send({ active_arena_history_id: active ? active.arena_history_id : null, saved_arenas: arenas });
+  respondSuccess(res, 200, {
+    active_arena_history_id: active ? active.arena_history_id : null,
+    saved_arenas: arenas,
+  });
 }
 
 export async function create(req: Request, res: Response) {
   const { name, size } = req.body || {};
-  if (!name || !size) return res.status(400).send('Missing required fields');
+  if (!name || !size) {
+    return respondError(res, 400, 'invalid_payload', 'Missing required fields');
+  }
   // generate a seed server-side for parity with legacy
   const seed = (req as any).seed || Math.random().toString(36).slice(2);
   await service.createArenaHistory({ name, seed, size: Number(size) });
   const arenas = await service.listArenaHistories();
   if (req.app && req.app.locals && req.app.locals.arena) req.app.locals.arena.terrain = null;
-  res.send(arenas);
+  respondSuccess(res, 201, arenas, 'Arena created');
 }

--- a/server/src/modules/arena/arena.routes.ts
+++ b/server/src/modules/arena/arena.routes.ts
@@ -1,19 +1,21 @@
 import { Router } from 'express';
 import * as controller from './arena.controller';
+import { respondError, respondSuccess } from '../../utils/apiResponse';
 
 const router = Router();
 
-router.post('/move', (req, res) => {
+router.post('/move', (_req, res) => {
   // Movement validation was legacy; stubbed to return false/accepted false for now
-  res.send(false);
+  respondSuccess(res, 200, false);
 });
 
 router.get('/terrain', (req, res) => {
   if (req.app && req.app.locals && req.app.locals.arena && req.app.locals.arena.seed) {
-    res.json({ seed: req.app.locals.arena.seed });
-  } else {
-    res.status(404).send('arena seed not set');
+    respondSuccess(res, 200, { seed: req.app.locals.arena.seed });
+    return;
   }
+
+  respondError(res, 404, 'not_found', 'Arena seed not set');
 });
 
 router.get('/list', controller.list);

--- a/server/src/modules/character/character.controller.ts
+++ b/server/src/modules/character/character.controller.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express';
 import { characterService, buildCharacterWithEquipment } from './character.service';
+import { respondError, respondSuccess } from '../../utils/apiResponse';
 
 export const characterController = {
   logout: async (req: Request, res: Response) => {
@@ -9,77 +10,79 @@ export const characterController = {
       await characterService.deactivateCharacters((req.user as any).id);
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
-      req.logout(() => res.json({ success: true }));
+      req.logout(() => respondSuccess(res, 200, { loggedOut: true }, 'Logged out'));
     } catch (err) {
       console.error(err);
-      res.status(500).json({ error: 'Server error during logout' });
+      respondError(res, 500, 'internal_error', 'Server error during logout');
     }
   },
 
   refresh: async (req: Request, res: Response) => {
     try {
       const rawUserId = req.user && (req.user as any).id ? (req.user as any).id : null;
-      if (!rawUserId) return res.status(401).json({ error: 'Not authenticated' });
+      if (!rawUserId) return respondError(res, 401, 'not_authenticated', 'Not authenticated');
       const userId = Number(rawUserId);
       const character = await characterService.getActiveCharacterForUser(userId);
-      if (!character || !character.id) return res.status(404).json({ error: 'No active character found' });
+      if (!character || !character.id) return respondError(res, 404, 'no_active_character', 'No active character found');
       try {
         const charWithEquip = await buildCharacterWithEquipment(character);
-        res.json({ success: true, character: charWithEquip });
+        respondSuccess(res, 200, { character: charWithEquip });
       } catch (e) {
         console.warn('Failed to load equipment for character', character.id, e);
-        res.json({ success: true, character });
+        respondSuccess(res, 200, { character });
       }
     } catch (err) {
       console.error(err);
-      res.status(500).json({ error: 'An error occurred' });
+      respondError(res, 500, 'internal_error', 'An error occurred');
     }
   },
 
   selectCharacter: async (req: Request, res: Response) => {
     try {
       const rawUserId = req.user && (req.user as any).id ? (req.user as any).id : null;
-      if (!rawUserId) return res.status(401).json({ error: 'Not authenticated' });
+      if (!rawUserId) return respondError(res, 401, 'not_authenticated', 'Not authenticated');
       const userId = Number(rawUserId);
       const { characterId } = req.body;
       await characterService.deactivateCharacters(userId);
       const rows = await characterService.activateCharacter(userId, characterId);
-      if (!rows || (rows as any).count === 0) return res.status(404).json({ error: 'No character found or updated' });
+      if (!rows || (rows as any).count === 0) {
+        return respondError(res, 404, 'no_character_updated', 'No character found or updated');
+      }
       const character = await characterService.getActiveCharacterForUser(userId);
-      if (!character || !character.id) return res.status(404).json({ error: 'No active character found' });
+      if (!character || !character.id) return respondError(res, 404, 'no_active_character', 'No active character found');
 
       try {
         const charWithEquip = await buildCharacterWithEquipment(character);
         const containers = await characterService.getContainersForCharacter(character.id);
-        res.json({ success: true, character: charWithEquip, containers });
+        respondSuccess(res, 200, { character: charWithEquip, containers });
       } catch (e) {
         console.warn('Failed to load equipment for character', character.id, e);
-        res.json({ success: true, character });
+        respondSuccess(res, 200, { character });
       }
     } catch (err) {
       console.error(err);
-      res.status(500).json({ error: 'An error occurred' });
+      respondError(res, 500, 'internal_error', 'An error occurred');
     }
   },
 
   createCharacter: async (req: Request, res: Response) => {
     try {
       const rawUserId = req.user && (req.user as any).id ? (req.user as any).id : null;
-      if (!rawUserId) return res.status(401).json({ error: 'Not authenticated' });
+      if (!rawUserId) return respondError(res, 401, 'not_authenticated', 'Not authenticated');
       const userId = Number(rawUserId);
       const { name, raceId, image } = req.body;
       const createdChar = await characterService.createCharacterForUser(userId, { name, raceId, image });
-      res.status(200).json({ success: true, character: createdChar });
+      respondSuccess(res, 201, { character: createdChar }, 'Character created');
     } catch (err) {
       console.error(err);
-      res.status(500).json({ error: 'Internal server error' });
+      respondError(res, 500, 'internal_error', 'Internal server error');
     }
   },
 
   listCharacters: async (req: Request, res: Response) => {
     try {
       const rawUserId = req.user && (req.user as any).id ? (req.user as any).id : null;
-      if (!rawUserId) return res.status(401).json({ error: 'Not authenticated' });
+      if (!rawUserId) return respondError(res, 401, 'not_authenticated', 'Not authenticated');
       const userId = Number(rawUserId);
       const rows = await characterService.listCharactersForUser(userId);
       const characterList = rows.map((row: any) => ({
@@ -88,10 +91,10 @@ export const characterController = {
         level: 1,
         vessels: [{ color: '#156156' }, { color: '#a12078' }],
       }));
-      res.json({ success: true, characters: characterList });
+      respondSuccess(res, 200, { characters: characterList });
     } catch (e) {
       console.error(e);
-      res.status(500).json({ error: 'Server Error' });
+      respondError(res, 500, 'internal_error', 'Server Error');
     }
   },
 };

--- a/server/src/modules/character/character.service.ts
+++ b/server/src/modules/character/character.service.ts
@@ -28,6 +28,7 @@ export async function getContainersForCharacter(characterId: number) {
   return containers.map((c: any) => ({
     ...c,
     containerType: c.containerType || 'BASIC',
+    icon: c.icon ?? null,
     items: (c.items || []).map(mapItemForClient),
   }));
 }

--- a/server/src/modules/data/data.controller.ts
+++ b/server/src/modules/data/data.controller.ts
@@ -1,8 +1,9 @@
 import { Request, Response } from 'express';
 import { asyncHandler } from '../../utils/asyncHandler';
+import { respondSuccess } from '../../utils/apiResponse';
 import { listRaces } from './data.service';
 
 export const getRaces = asyncHandler(async (_req: Request, res: Response) => {
   const rows = await listRaces();
-  res.json({ success: true, races: rows });
+  respondSuccess(res, 200, { races: rows });
 });

--- a/server/src/modules/dm/dm.routes.ts
+++ b/server/src/modules/dm/dm.routes.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import wss from '../../lib/socket';
 import Encounter from './encounter';
+import { respondSuccess } from '../../utils/apiResponse';
 
 const router = Router();
 
@@ -8,7 +9,7 @@ router.post('/combat/start', async (req, res) => {
   const encounter = new Encounter();
   req.session.encounter = encounter;
   wss.send('combat_start', encounter);
-  res.sendStatus(200);
+  respondSuccess(res, 200, { encounter });
 });
 
 router.post('/combat/end', async (req, res) => {
@@ -18,7 +19,7 @@ router.post('/combat/end', async (req, res) => {
   }
   wss.send('combat_end', encounter);
   req.session.encounter = null;
-  res.sendStatus(200);
+  respondSuccess(res, 200, { encounterEnded: true });
 });
 
 export default router;

--- a/server/src/modules/equipment/equipment.controller.ts
+++ b/server/src/modules/equipment/equipment.controller.ts
@@ -1,33 +1,36 @@
 import { Request, Response } from 'express';
 import { asyncHandler } from '../../utils/asyncHandler';
-import { equipItemToCharacter, unequipItemFromSlot, listEquipmentForCharacter, performEquipForCharacter, unequipItemToContainer } from './equipment.service';
+import { respondError, respondSuccess } from '../../utils/apiResponse';
+import { listEquipmentForCharacter, performEquipForCharacter, unequipItemToContainer } from './equipment.service';
 import { characterService } from '../character/character.service';
 import { EquipmentSlot } from '@prisma/client';
 import { DomainError } from './equipment.domain';
 
 export const postEquip = asyncHandler(async (req: Request, res: Response) => {
   const rawUserId = req.user && (req.user as any).id ? (req.user as any).id : null;
-  if (!rawUserId) return res.status(400).json({ error: 'No active character' });
+  if (!rawUserId) return respondError(res, 400, 'no_active_character', 'No active character');
   const userId = Number(rawUserId);
   const character = await characterService.getActiveCharacterForUser(userId);
-  if (!character) return res.status(400).json({ error: 'No active character' });
+  if (!character) return respondError(res, 400, 'no_active_character', 'No active character');
   const { itemId, slot } = req.body;
-  if (!itemId || !slot) return res.status(400).json({ error: 'itemId and slot required' });
+  if (!itemId || !slot) {
+    return respondError(res, 400, 'invalid_payload', 'itemId and slot required');
+  }
 
   // Validate slot string against the Prisma enum keys to catch client drift early.
   if (!Object.prototype.hasOwnProperty.call(EquipmentSlot, slot)) {
-    return res.status(400).json({ error: 'invalid slot', slot });
+    return respondError(res, 400, 'invalid_slot', 'Invalid slot', { slot });
   }
 
   try {
-  // Use performEquipForCharacter so we return the full envelope the client
-  // expects (equipment rows + containers + capacity metadata).
-  const updated = await performEquipForCharacter(character.id, Number(itemId), slot as any);
-  res.json(updated);
+    // Use performEquipForCharacter so we return the full envelope the client
+    // expects (equipment rows + containers + capacity metadata).
+    const updated = await performEquipForCharacter(character.id, Number(itemId), slot as any);
+    respondSuccess(res, 200, updated, 'Equipment updated');
   } catch (err: any) {
     // If it's a domain error, surface its code to the client for clearer handling.
     if (err instanceof DomainError) {
-      return res.status(400).json({ error: err.message, code: err.code });
+      return respondError(res, 400, err.code, err.message);
     }
     throw err;
   }
@@ -35,32 +38,32 @@ export const postEquip = asyncHandler(async (req: Request, res: Response) => {
 
 export const postUnequip = asyncHandler(async (req: Request, res: Response) => {
   const rawUserId = req.user && (req.user as any).id ? (req.user as any).id : null;
-  if (!rawUserId) return res.status(400).json({ error: 'No active character' });
+  if (!rawUserId) return respondError(res, 400, 'no_active_character', 'No active character');
   const userId = Number(rawUserId);
   const character = await characterService.getActiveCharacterForUser(userId);
-  if (!character) return res.status(400).json({ error: 'No active character' });
+  if (!character) return respondError(res, 400, 'no_active_character', 'No active character');
 
   // Minimal trusted payload from client
   const { itemId, containerId, containerIndex } = req.body || {};
-  if (!itemId) return res.status(400).json({ error: 'itemId required' });
-  if (typeof containerId === 'undefined') return res.status(400).json({ error: 'containerId required' });
-  if (typeof containerIndex === 'undefined') return res.status(400).json({ error: 'containerIndex required' });
+  if (!itemId) return respondError(res, 400, 'invalid_payload', 'itemId required');
+  if (typeof containerId === 'undefined') return respondError(res, 400, 'invalid_payload', 'containerId required');
+  if (typeof containerIndex === 'undefined') return respondError(res, 400, 'invalid_payload', 'containerIndex required');
 
   try {
     const result = await unequipItemToContainer(character.id, Number(itemId), Number(containerId), Number(containerIndex));
-    return res.json({ success: true, item: result.item, changed: result.changed });
+    return respondSuccess(res, 200, { item: result.item, changed: result.changed }, 'Item unequipped');
   } catch (err: any) {
-    if (err instanceof DomainError) return res.status(400).json({ error: err.message, code: err.code });
+    if (err instanceof DomainError) return respondError(res, 400, err.code, err.message);
     throw err;
   }
 });
 
 export const getList = asyncHandler(async (req: Request, res: Response) => {
   const rawUserId = req.user && (req.user as any).id ? (req.user as any).id : null;
-  if (!rawUserId) return res.status(200).json([]);
+  if (!rawUserId) return respondSuccess(res, 200, []);
   const userId = Number(rawUserId);
   const character = await characterService.getActiveCharacterForUser(userId);
-  if (!character) return res.status(200).json([]);
+  if (!character) return respondSuccess(res, 200, []);
   const list = await listEquipmentForCharacter(character.id);
-  res.json(list);
+  respondSuccess(res, 200, list);
 });

--- a/server/src/modules/user/user.controller.ts
+++ b/server/src/modules/user/user.controller.ts
@@ -1,33 +1,40 @@
 import { Request, Response } from 'express';
 import { userService } from './user.service';
 import { DomainError } from './user.domain';
+import { respondError, respondSuccess } from '../../utils/apiResponse';
 
 export const userController = {
   create: async (req: Request, res: Response) => {
     const { email, password, displayName } = req.body;
     // Transport-level basic checks
     if (typeof email !== 'string' || typeof password !== 'string' || typeof displayName !== 'string') {
-      return res.status(422).json({ error: 'invalid_payload' });
+      return respondError(res, 422, 'invalid_payload', 'Invalid registration payload');
     }
 
     try {
       const user = await userService.createUser(email, password, displayName);
-      res.status(201).json(user);
+      respondSuccess(res, 201, { user }, 'User created');
     } catch (e: any) {
       console.error(e);
       if (e instanceof DomainError) {
-        if (e.code === 'INVALID_EMAIL' || e.code === 'NAME_TOO_SHORT' || e.code === 'PASSWORD_REQUIRED') return res.status(422).json({ error: 'invalid_payload' });
-        if (e.code === 'EMAIL_IN_USE') return res.status(409).json({ error: 'email_in_use' });
+        if (e.code === 'INVALID_EMAIL' || e.code === 'NAME_TOO_SHORT' || e.code === 'PASSWORD_REQUIRED') {
+          return respondError(res, 422, 'invalid_payload', e.message);
+        }
+        if (e.code === 'EMAIL_IN_USE') {
+          return respondError(res, 409, 'email_in_use', e.message);
+        }
       }
-      res.status(500).json({ error: 'unexpected' });
+      respondError(res, 500, 'unexpected', 'Unexpected error');
     }
   },
   getOne: async (req: Request, res: Response) => {
     const { id } = req.params;
     const idNum = Number(id);
-    if (!Number.isInteger(idNum) || idNum <= 0) return res.status(400).json({ error: 'invalid_id' });
+    if (!Number.isInteger(idNum) || idNum <= 0) {
+      return respondError(res, 400, 'invalid_id', 'Invalid user id');
+    }
     const user = await userService.getUser(idNum);
-    if (!user) return res.status(404).json({ error: 'not_found' });
-    res.json(user);
+    if (!user) return respondError(res, 404, 'not_found', 'User not found');
+    respondSuccess(res, 200, { user });
   },
 };

--- a/server/src/modules/world/dungeons.controller.ts
+++ b/server/src/modules/world/dungeons.controller.ts
@@ -1,16 +1,17 @@
 import { Request, Response } from 'express';
 import { listLocationsByType, getLocationByType, createLocationOfType } from './location.service';
 import { DomainError, assertTypeMatches } from './world.domain';
+import { respondError, respondSuccess } from '../../utils/apiResponse';
 
 const DUNGEON_TYPE = 'DUNGEON';
 
 export async function index(_req: Request, res: Response) {
   try {
     const items = await listLocationsByType(DUNGEON_TYPE);
-    res.json(items);
+    respondSuccess(res, 200, items);
   } catch (e) {
     console.error(e);
-    res.status(500).send('Server Error');
+    respondError(res, 500, 'internal_error', 'Server Error');
   }
 }
 
@@ -18,32 +19,34 @@ export async function show(req: Request, res: Response) {
   try {
     const item = await getLocationByType(req.params.id, DUNGEON_TYPE);
     if (!item) {
-      res.status(404).send('Not Found');
+      respondError(res, 404, 'not_found', 'Dungeon not found');
       return;
     }
     try {
       assertTypeMatches(item, DUNGEON_TYPE);
-      res.json(item);
+      respondSuccess(res, 200, item);
     } catch (e) {
-      if (e instanceof DomainError && e.code === 'TYPE_MISMATCH') return res.status(404).send('Not Found');
+      if (e instanceof DomainError && e.code === 'TYPE_MISMATCH') return respondError(res, 404, 'not_found', 'Dungeon not found');
       throw e;
     }
   } catch (e) {
     console.error(e);
-    res.status(500).send('Server Error');
+    respondError(res, 500, 'internal_error', 'Server Error');
   }
 }
 
 export async function create(req: Request, res: Response) {
   try {
     const created = await createLocationOfType(DUNGEON_TYPE, req.body ?? {});
-    res.status(201).json(created);
+    respondSuccess(res, 201, created, 'Dungeon created');
   } catch (e) {
     console.error(e);
     if (e instanceof DomainError) {
-      if (e.code === 'NAME_REQUIRED') return res.status(422).json({ error: 'invalid_name' });
-      if (e.code === 'INVALID_TYPE' || e.code === 'INVALID_ADVENTURE') return res.status(422).json({ error: 'invalid_payload' });
+      if (e.code === 'NAME_REQUIRED') return respondError(res, 422, 'invalid_name', 'Name is required');
+      if (e.code === 'INVALID_TYPE' || e.code === 'INVALID_ADVENTURE') {
+        return respondError(res, 422, 'invalid_payload', 'Invalid payload');
+      }
     }
-    res.status(500).send('Server Error');
+    respondError(res, 500, 'internal_error', 'Server Error');
   }
 }

--- a/server/src/modules/world/locations.controller.ts
+++ b/server/src/modules/world/locations.controller.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import { listLocations, createLocation, getLocation, deleteLocation } from './location.service';
 import { DomainError } from './world.domain';
+import { respondError, respondSuccess } from '../../utils/apiResponse';
 
 export async function index(req: Request, res: Response) {
   try {
@@ -8,24 +9,24 @@ export async function index(req: Request, res: Response) {
     if (req.query.chunkX) filter.chunkX = Number(req.query.chunkX);
     if (req.query.chunkY) filter.chunkY = Number(req.query.chunkY);
     const items = await listLocations(filter);
-    res.json(items);
+    respondSuccess(res, 200, items);
   } catch (e) {
     console.error(e);
-    res.status(500).send('Server Error');
+    respondError(res, 500, 'internal_error', 'Server Error');
   }
 }
 
 export async function create(req: Request, res: Response) {
   try {
     const created = await createLocation(req.body);
-    res.status(201).json(created);
+    respondSuccess(res, 201, created, 'Location created');
   } catch (e) {
     console.error(e);
     if (e instanceof DomainError) {
-      if (e.code === 'NAME_REQUIRED') return res.status(422).json({ error: 'invalid_name' });
-      if (e.code === 'INVALID_ADVENTURE') return res.status(422).json({ error: 'invalid_adventure' });
+      if (e.code === 'NAME_REQUIRED') return respondError(res, 422, 'invalid_name', 'Name is required');
+      if (e.code === 'INVALID_ADVENTURE') return respondError(res, 422, 'invalid_adventure', 'Invalid adventure');
     }
-    res.status(500).send('Server Error');
+    respondError(res, 500, 'internal_error', 'Server Error');
   }
 }
 
@@ -33,22 +34,22 @@ export async function show(req: Request, res: Response) {
   try {
     const item = await getLocation(req.params.id);
     if (!item) {
-      res.status(404).send('Not Found');
+      respondError(res, 404, 'not_found', 'Location not found');
       return;
     }
-    res.json(item);
+    respondSuccess(res, 200, item);
   } catch (e) {
     console.error(e);
-    res.status(500).send('Server Error');
+    respondError(res, 500, 'internal_error', 'Server Error');
   }
 }
 
 export async function destroy(req: Request, res: Response) {
   try {
     const deleted = await deleteLocation(req.params.id);
-    res.json(deleted);
+    respondSuccess(res, 200, deleted, 'Location deleted');
   } catch (e) {
     console.error(e);
-    res.status(500).send('Server Error');
+    respondError(res, 500, 'internal_error', 'Server Error');
   }
 }

--- a/server/src/modules/world/world.routes.ts
+++ b/server/src/modules/world/world.routes.ts
@@ -2,18 +2,20 @@ import { Router } from 'express';
 import locations from './locations.routes';
 import towns from './towns.routes';
 import dungeons from './dungeons.routes';
+import { respondError, respondSuccess } from '../../utils/apiResponse';
 
 const router = Router();
 
 router.get('/seed', (req, res) => {
   if (res.app.locals.world && res.app.locals.world.seed) {
-    res.json({ seed: res.app.locals.world.seed });
-  } else {
-    res.status(404).send('world seed not set');
+    respondSuccess(res, 200, { seed: res.app.locals.world.seed });
+    return;
   }
+
+  respondError(res, 404, 'not_found', 'World seed not set');
 });
 
-router.post('/move', (_req, res) => res.json({ success: true }));
+router.post('/move', (_req, res) => respondSuccess(res, 200, { moved: true }));
 
 router.use('/locations', locations);
 router.use('/towns', towns);

--- a/server/src/routes/open.test.ts
+++ b/server/src/routes/open.test.ts
@@ -1,0 +1,70 @@
+import express from 'express';
+import request from 'supertest';
+import passport from 'passport';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import openRouter from './open';
+
+const buildApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    Object.assign(req, {
+      logIn: (_user: unknown, done: (err?: unknown) => void) => done(),
+    });
+    next();
+  });
+  app.use('/open', openRouter);
+  return app;
+};
+
+describe('POST /open/login', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns standardized error envelope when authentication fails', async () => {
+    const app = buildApp();
+    const authenticateMock = vi
+      .spyOn(passport, 'authenticate')
+      .mockImplementation((_strategy, callback) => () => {
+        if (typeof callback === 'function') {
+          callback(null, false, { message: 'Invalid credentials' });
+        }
+      });
+
+    const response = await request(app).post('/open/login').send({ email: 'user@example.com', password: 'wrong' });
+
+    expect(authenticateMock).toHaveBeenCalled();
+    expect(response.status).toBe(401);
+    expect(response.body).toEqual({
+      success: false,
+      error: {
+        code: 'unauthorized',
+        message: 'Invalid credentials',
+      },
+    });
+  });
+
+  it('returns standardized success envelope when authentication succeeds', async () => {
+    const app = buildApp();
+    const user = { displayName: 'Tester' } as any;
+    const authenticateMock = vi
+      .spyOn(passport, 'authenticate')
+      .mockImplementation((_strategy, callback) => () => {
+        if (typeof callback === 'function') {
+          callback(null, user, undefined);
+        }
+      });
+
+    const response = await request(app).post('/open/login').send({ email: 'user@example.com', password: 'correct' });
+
+    expect(authenticateMock).toHaveBeenCalled();
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      success: true,
+      data: { displayName: 'Tester' },
+      message: 'Login successful',
+    });
+  });
+});

--- a/server/src/utils/apiResponse.ts
+++ b/server/src/utils/apiResponse.ts
@@ -1,0 +1,73 @@
+import type { Response } from 'express';
+
+export type ApiSuccessResponse<TData = unknown> = {
+  success: true;
+  data: TData;
+  message?: string;
+  meta?: Record<string, unknown>;
+};
+
+export type ApiErrorResponse = {
+  success: false;
+  error: {
+    code: string;
+    message: string;
+    details?: Record<string, unknown>;
+  };
+  meta?: Record<string, unknown>;
+};
+
+export type ApiResponse<TData = unknown> = ApiSuccessResponse<TData> | ApiErrorResponse;
+
+export const buildSuccess = <TData>(
+  data: TData,
+  message?: string,
+  meta?: Record<string, unknown>,
+): ApiSuccessResponse<TData> => {
+  const response: ApiSuccessResponse<TData> = {
+    success: true,
+    data,
+  };
+
+  if (message) response.message = message;
+  if (meta) response.meta = meta;
+
+  return response;
+};
+
+export const buildError = (
+  code: string,
+  message?: string,
+  details?: Record<string, unknown>,
+  meta?: Record<string, unknown>,
+): ApiErrorResponse => {
+  const response: ApiErrorResponse = {
+    success: false,
+    error: {
+      code,
+      message: message ?? code,
+    },
+  };
+
+  if (details && Object.keys(details).length > 0) response.error.details = details;
+  if (meta) response.meta = meta;
+
+  return response;
+};
+
+export const respondSuccess = <TData>(
+  res: Response,
+  status: number,
+  data: TData,
+  message?: string,
+  meta?: Record<string, unknown>,
+): Response<ApiSuccessResponse<TData>> => res.status(status).json(buildSuccess(data, message, meta));
+
+export const respondError = (
+  res: Response,
+  status: number,
+  code: string,
+  message?: string,
+  details?: Record<string, unknown>,
+  meta?: Record<string, unknown>,
+): Response<ApiErrorResponse> => res.status(status).json(buildError(code, message, details, meta));


### PR DESCRIPTION
## Summary
- register the Express 404 fallback and error middleware so every route returns the standardized API envelope while keeping the health check unauthenticated
- refactor the open login route to handle passport success and failure cases via the shared respondSuccess/respondError helpers
- add backend test coverage for health/404 responses, login flows, middleware error handling, and authorization behavior using supertest

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d9cd3325b48327917a0550c5e03131