### PR TITLE
Propagate slot highlight state to inventory grid

### DIFF
--- a/client/src/components/shared/Slot.vue
+++ b/client/src/components/shared/Slot.vue
@@ -31,7 +31,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted, onBeforeUnmount, computed } from "vue";
+import { ref, onMounted, onBeforeUnmount, computed, watch } from "vue";
 import DraggableItem from "@/components/inventory/DraggableItem.vue";
 import { mdiClose } from "@mdi/js";
 import dragEventBus from "@/lib/dragEventBus";
@@ -48,9 +48,13 @@ const props = defineProps({
   icon: { type: String, default: null },
 });
 
-const emit = defineEmits(["click", "dropped"]);
+const emit = defineEmits(["click", "dropped", "highlight-change"]);
 
 const isDragHighlighted = ref(false);
+
+watch(isDragHighlighted, (highlighted) => {
+  emit("highlight-change", highlighted);
+});
 
 const slotStyle = computed(() => {
   const s = { position: "relative", width: "100%", height: "100%" };


### PR DESCRIPTION
## Summary
- emit a `highlight-change` event from `Slot` whenever its drag highlight toggles
- have `InventoryGrid` derive pack highlight styling from slot events instead of its own drag listeners

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9df8a2864832794123103bbbe04f8