### PR TITLE
Fix pocket highlight for unequipped containers

### DIFF
--- a/client/src/components/inventory/DraggableItem.vue
+++ b/client/src/components/inventory/DraggableItem.vue
@@ -138,15 +138,28 @@ function onMouseEnter() {
         ((props.item.container && props.item.container.id) ||
           props.item.providesContainerId)) ||
       null;
+    const isContainerItem = Boolean(
+      props.item &&
+        (props.item.isContainer ||
+          props.item.container ||
+          props.item.providesContainerId != null)
+    );
     const sourceContainerId =
       (props.source && props.source.containerId) ||
       (props.item && props.item.containerId) ||
       null;
-    const cid = providedContainerId != null ? providedContainerId : sourceContainerId;
-    dragEventBus.emit("container-hover", {
-      containerId: cid,
-      item: props.item,
-    });
+    const cid =
+      providedContainerId != null
+        ? providedContainerId
+        : !isContainerItem
+        ? sourceContainerId
+        : null;
+    if (cid != null) {
+      dragEventBus.emit("container-hover", {
+        containerId: cid,
+        item: props.item,
+      });
+    }
   } catch (e) {
     /* ignore */
   }


### PR DESCRIPTION
## Summary
- prevent container items from highlighting their source pockets when they do not expose a container
- only emit hover highlight events when a container id is available

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da34b49a248327a6447ed687cc2980